### PR TITLE
Improve Pose2Text dataset speed

### DIFF
--- a/multimodalhugs/data/datasets/pose2text.py
+++ b/multimodalhugs/data/datasets/pose2text.py
@@ -5,6 +5,7 @@ import datasets
 
 from pathlib import Path
 from pose_format import Pose
+from pose_format.pose_body import EmptyPoseBody
 from typing import Any, Union, Dict, Optional
 from datasets import load_dataset, Dataset, DatasetInfo, SplitGenerator, Features
 from dataclasses import dataclass, field
@@ -217,8 +218,9 @@ class Pose2TextDataset(datasets.GeneratorBasedBuilder):
             # [t, people, d, xyz]
             pose = Pose.read(buffer, 
                              start_time=sample['signal_start'] or None, 
-                             end_time=sample['signal_end'] or None) 
-            sample['DURATION'] = len(pose.body.data)
+                             end_time=sample['signal_end'] or None,
+                             pose_body=EmptyPoseBody) 
+            sample['DURATION'] = len(pose.body)
 
             return sample
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "Pillow",
     "evaluate",
     "signwriting @ git+https://github.com/sign-language-processing/signwriting",
-    "pose-format>=0.9.0",
+    "pose-format>=0.10.0",
     "ruamel.yaml",
     "av>=10.0.0",
 ]


### PR DESCRIPTION
This is incomplete. 

Still need to:
> we need to update the logic of buffer = read_pose_buffer(sample['signal']) - if the pose only exists once, we should send the file io handler and not read the buffer. if the pose exists multiple times in the dataset, we should read the buffer and cache it.

fixes #45 