### PR TITLE
Lazy optional imports and modality-specific extras

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
         # Use the Python version that matches your development environment
 
     - name: Install dependencies
-      run: pip install .[dev]
+      run: pip install ".[full,dev]"
 
     - name: Run tests
       run: pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,19 @@ Each version section may have subsections for: _Added_, _Changed_, _Removed_, _D
 
 ### Fixed
 
-- **Partial installation now works as expected.** Previously, importing any part of `multimodalhugs` required all modality-specific dependencies (`pose-format`, `opencv-python`, `signwriting`, `av`, `torchvision`) to be installed, even if the user only intended to use a single modality (e.g. text-to-text). This was caused by two issues: (1) eager `from .tasks import *` in `__init__.py` transitively forced `av` and `cv2` to be imported at package load time via `evaluate → transformers.pipelines.video_classification`; and (2) modality processors and datasets imported their optional dependencies unconditionally at module level.
+- **Partial installation now works as expected.** Previously, importing any part of `multimodalhugs` required all modality-specific dependencies (`pose-format`, `opencv-python`, `signwriting`, `av`, `torchvision`) to be installed, even if the user only intended to use a single modality (e.g. text-to-text). The root causes and their fixes are described below.
+
+- **`multimodalhugs/data/__init__.py`**: Dataset classes (`Pose2TextDataset`, `Video2TextDataset`, etc.) were imported eagerly at package load time, pulling in their optional dependencies immediately. Replaced with PEP 562 `__getattr__` lazy loading — each dataset module is only imported when the class is explicitly accessed.
+
+- **`multimodalhugs/training_setup/general_training_setup.py`**: `_build_dataset_map()` imported all six dataset modules upfront, so running `mmhugs-setup` for any modality (e.g. `features2text`) would also import `pose2text.py`, triggering a `NameError` on the `-> Pose` return annotation when `pose-format` was not installed. Replaced with a `_DATASET_IMPORT_MAP` string table and `_load_dataset_classes(dataset_type)` that only imports the one module actually needed. `_build_dataset_map()` is retained as a public helper (now lazy) for tests and tooling.
+
+- **`multimodalhugs/data/utils.py`**: `from torchvision.transforms import ...` was imported unconditionally at module level, causing `ModuleNotFoundError` for users in pose-only or text-only environments. Wrapped in `try/except ImportError` with a `_TORCHVISION_AVAILABLE` flag.
+
+- **`multimodalhugs/data/datasets/features2text.py`**: Removed a dead `from pose_format import Pose` import that was never used in the file but caused `ModuleNotFoundError` in environments without `pose-format`.
+
+- **`multimodalhugs/__init__.py`**: `from .tasks import *` transitively forced `av` to be imported at package load time via `evaluate → transformers.pipelines.video_classification`. Removed.
+
+- **`multimodalhugs/tasks/translation/translation_training.py`** and **`translation_generate.py`**: `import evaluate` was at module top-level, which transitively imported `transformers.pipelines.video_classification → av`. Moved inside the function body, just before `evaluate.load()` is called. In `translation_training.py` the import is additionally conditional on `metric_name` being set, so environments without a metric configured avoid the `av` dependency entirely.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Each version section may have subsections for: _Added_, _Changed_, _Removed_, _D
 
 ### Breaking Changes
 
-- **`from multimodalhugs import <DatasetClass>` required a fix.** The switch to lazy loading in `data/__init__.py` meant that PEP 562 `__getattr__` names were not visible to wildcard imports (`from .data import *`), so `from multimodalhugs import Pose2TextDataset` silently stopped working. Fixed by adding a `__getattr__` to `multimodalhugs/__init__.py` that delegates dataset-class lookups to `multimodalhugs.data`. The import `from multimodalhugs.data import Pose2TextDataset` was never affected.
+- **`from multimodalhugs import Pose2TextDataset`** (and other dataset builder classes) no longer works. Dataset builders are internal construction details, not user-facing API — no example, doc, or internal caller relied on the top-level shorthand. Use the fully-qualified form instead: `from multimodalhugs.data import Pose2TextDataset`.
 
 - **`from multimodalhugs import translation_training_main`** (and other `tasks` re-exports) now raises `ImportError`. Removing `from .tasks import *` from `multimodalhugs/__init__.py` broke direct top-level access to task entry points. Use `from multimodalhugs.tasks.translation.translation_training import main` instead.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ Version numbers are of the form `1.0.0`.
 
 Each version section may have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [0.5.1]
+
+### Fixed
+
+- **Partial installation now works as expected.** Previously, importing any part of `multimodalhugs` required all modality-specific dependencies (`pose-format`, `opencv-python`, `signwriting`, `av`, `torchvision`) to be installed, even if the user only intended to use a single modality (e.g. text-to-text). This was caused by two issues: (1) eager `from .tasks import *` in `__init__.py` transitively forced `av` and `cv2` to be imported at package load time via `evaluate → transformers.pipelines.video_classification`; and (2) modality processors and datasets imported their optional dependencies unconditionally at module level.
+
+### Changed
+
+- **`pyproject.toml`**: Modality-specific dependencies moved from core `dependencies` to optional extras. Users can now install only what they need:
+  - `pip install "multimodalhugs[full]"` — all modalities (equivalent to the previous default)
+  - `pip install "multimodalhugs[pose]"` — pose sequences (`pose-format`)
+  - `pip install "multimodalhugs[video]"` — video (`av`, `torchvision`, `opencv-python`)
+  - `pip install "multimodalhugs[signwriting]"` — SignWriting (`signwriting`)
+  - `pip install "multimodalhugs[image]"` — images (`opencv-python`)
+  - Multiple extras can be combined: `pip install "multimodalhugs[pose,video]"`
+
+- **`multimodalhugs/__init__.py`**: Removed `from .tasks import *` and `from .multimodalhugs_cli import *`. The CLI entry points (`mmhugs-train`, `mmhugs-generate`, `mmhugs-setup`) are unaffected — they are declared as `console_scripts` in `pyproject.toml` and call their target functions directly. The training entry points remain accessible via explicit import: `from multimodalhugs.tasks import translation_training_main`.
+
+- **Modality processors** (`PoseModalityProcessor`, `VideoModalityProcessor`, `SignwritingModalityProcessor`, `ImageModalityProcessor`): Optional dependency imports are now wrapped in `try/except ImportError`. A clear `ImportError` with a `pip install` hint is raised at instantiation time if the required package is absent, rather than at module import time.
+
+- **Modality datasets** (`Pose2TextDataset`, `SignWritingDataset`, `Video2TextDataset`): Same lazy-import pattern applied — optional dependency imports wrapped in `try/except`, with a descriptive `ImportError` raised in `__init__` if the dependency is missing.
+
+---
+
 ## [0.5.0]
 
 This release introduces a complete redesign of the processor layer, replacing the six monolithic task-specific processors with a modular, composable architecture. The new design separates modality-specific preprocessing from task structure, enables declarative YAML configuration, and provides a unified CLI entry point for all modalities. Full backward compatibility is maintained — existing code, configs, and processor checkpoints continue to work unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ Each version section may have subsections for: _Added_, _Changed_, _Removed_, _D
 
 - **Modality datasets** (`Pose2TextDataset`, `SignWritingDataset`, `Video2TextDataset`): Same lazy-import pattern applied — optional dependency imports wrapped in `try/except`, with a descriptive `ImportError` raised in `__init__` if the dependency is missing.
 
+### Breaking Changes
+
+- **`from multimodalhugs import <DatasetClass>` required a fix.** The switch to lazy loading in `data/__init__.py` meant that PEP 562 `__getattr__` names were not visible to wildcard imports (`from .data import *`), so `from multimodalhugs import Pose2TextDataset` silently stopped working. Fixed by adding a `__getattr__` to `multimodalhugs/__init__.py` that delegates dataset-class lookups to `multimodalhugs.data`. The import `from multimodalhugs.data import Pose2TextDataset` was never affected.
+
+- **`from multimodalhugs import translation_training_main`** (and other `tasks` re-exports) now raises `ImportError`. Removing `from .tasks import *` from `multimodalhugs/__init__.py` broke direct top-level access to task entry points. Use `from multimodalhugs.tasks.translation.translation_training import main` instead.
+
 ---
 
 ## [0.5.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ Each version section may have subsections for: _Added_, _Changed_, _Removed_, _D
 
 - **`from multimodalhugs import Pose2TextDataset`** (and other dataset builder classes) no longer works. Dataset builders are internal construction details, not user-facing API — no example, doc, or internal caller relied on the top-level shorthand. Use the fully-qualified form instead: `from multimodalhugs.data import Pose2TextDataset`.
 
+- **`from multimodalhugs.data import *` no longer includes dataset builder classes.** Because the six dataset classes (`Pose2TextDataset`, `Video2TextDataset`, `SignWritingDataset`, `BilingualText2TextDataset`, `BilingualImage2TextDataset`, `Features2TextDataset`) are now lazy-loaded via `__getattr__`, they are excluded from `__all__` and therefore silently absent from a wildcard import. Access them by name: `from multimodalhugs.data import Pose2TextDataset`.
+
 - **`from multimodalhugs import translation_training_main`** (and other `tasks` re-exports) now raises `ImportError`. Removing `from .tasks import *` from `multimodalhugs/__init__.py` broke direct top-level access to task entry points. Use `from multimodalhugs.tasks.translation.translation_training import main` instead.
 
 ---

--- a/README.md
+++ b/README.md
@@ -32,15 +32,23 @@ For more details, refer to the [documentation](docs/README.md).
 
 2. **Navigate and install the package**:
 
-   - **Standard installation**:
+   - **Full installation** (all modalities — recommended for most users):
       ```bash
        cd multimodalhugs
-       pip install .
+       pip install ".[full]"
+      ```
+   - **Modality-specific installation** (install only what you need):
+      ```bash
+       pip install ".[pose]"         # pose sequences (pose-format)
+       pip install ".[video]"        # video (av, torchvision, opencv-python)
+       pip install ".[signwriting]"  # SignWriting (signwriting)
+       pip install ".[image]"        # images (opencv-python)
+       pip install ".[pose,video]"   # combine multiple modalities
       ```
    - **Developer installation**:
       ```bash
        cd multimodalhugs
-       pip install -e .[dev]
+       pip install -e ".[full,dev]"
       ```
 
 ## Usage

--- a/multimodalhugs/__init__.py
+++ b/multimodalhugs/__init__.py
@@ -10,3 +10,24 @@ from .models import *
 from .utils import *
 from .multilingual_seq2seq_trainer import MultiLingualSeq2SeqTrainer
 
+# Dataset classes in multimodalhugs.data are loaded lazily via __getattr__ in
+# data/__init__.py (PEP 562). Wildcard imports (from .data import *) only copy
+# names already present in module.__dict__, so they do not trigger __getattr__
+# and the dataset classes never land in this namespace automatically.
+# The __getattr__ below forwards any dataset-class lookup to multimodalhugs.data,
+# preserving the pre-existing public API: `from multimodalhugs import Pose2TextDataset`.
+_DATA_DATASET_CLASSES = {
+    "Pose2TextDataset",
+    "Video2TextDataset",
+    "SignWritingDataset",
+    "BilingualText2TextDataset",
+    "BilingualImage2TextDataset",
+    "Features2TextDataset",
+}
+
+def __getattr__(name):
+    if name in _DATA_DATASET_CLASSES:
+        import multimodalhugs.data as _data
+        return getattr(_data, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+

--- a/multimodalhugs/__init__.py
+++ b/multimodalhugs/__init__.py
@@ -10,5 +10,3 @@ from .models import *
 from .utils import *
 from .multilingual_seq2seq_trainer import MultiLingualSeq2SeqTrainer
 
-from .tasks import *
-from .multimodalhugs_cli import *

--- a/multimodalhugs/__init__.py
+++ b/multimodalhugs/__init__.py
@@ -10,24 +10,3 @@ from .models import *
 from .utils import *
 from .multilingual_seq2seq_trainer import MultiLingualSeq2SeqTrainer
 
-# Dataset classes in multimodalhugs.data are loaded lazily via __getattr__ in
-# data/__init__.py (PEP 562). Wildcard imports (from .data import *) only copy
-# names already present in module.__dict__, so they do not trigger __getattr__
-# and the dataset classes never land in this namespace automatically.
-# The __getattr__ below forwards any dataset-class lookup to multimodalhugs.data,
-# preserving the pre-existing public API: `from multimodalhugs import Pose2TextDataset`.
-_DATA_DATASET_CLASSES = {
-    "Pose2TextDataset",
-    "Video2TextDataset",
-    "SignWritingDataset",
-    "BilingualText2TextDataset",
-    "BilingualImage2TextDataset",
-    "Features2TextDataset",
-}
-
-def __getattr__(name):
-    if name in _DATA_DATASET_CLASSES:
-        import multimodalhugs.data as _data
-        return getattr(_data, name)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-

--- a/multimodalhugs/data/__init__.py
+++ b/multimodalhugs/data/__init__.py
@@ -1,9 +1,27 @@
 from .utils import *
 from .dataset_configs.multimodal_mt_data_config import MultimodalDataConfig
-from .datasets.signwriting import SignWritingDataset
-from .datasets.pose2text import Pose2TextDataset
-from .datasets.video2text import Video2TextDataset
-from .datasets.bilingual_text2text import BilingualText2TextDataset
-from .datasets.bilingual_image2text import BilingualImage2TextDataset
-from .datasets.features2text import Features2TextDataset
 from .datacollators.multimodal_datacollator import DataCollatorMultimodalSeq2Seq
+
+# Dataset classes are loaded lazily so that importing multimodalhugs (or
+# multimodalhugs.data) does not execute modality-specific dataset modules —
+# and therefore does not require their optional dependencies — unless that
+# dataset class is explicitly accessed.
+_LAZY_DATASETS = {
+    "Pose2TextDataset":           ".datasets.pose2text",
+    "Video2TextDataset":          ".datasets.video2text",
+    "SignWritingDataset":          ".datasets.signwriting",
+    "BilingualText2TextDataset":  ".datasets.bilingual_text2text",
+    "BilingualImage2TextDataset": ".datasets.bilingual_image2text",
+    "Features2TextDataset":       ".datasets.features2text",
+}
+
+
+def __getattr__(name):
+    if name in _LAZY_DATASETS:
+        import importlib
+        module = importlib.import_module(_LAZY_DATASETS[name], package=__name__)
+        obj = getattr(module, name)
+        # Cache in module namespace so subsequent accesses skip __getattr__
+        globals()[name] = obj
+        return obj
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/multimodalhugs/data/__init__.py
+++ b/multimodalhugs/data/__init__.py
@@ -2,6 +2,38 @@ from .utils import *
 from .dataset_configs.multimodal_mt_data_config import MultimodalDataConfig
 from .datacollators.multimodal_datacollator import DataCollatorMultimodalSeq2Seq
 
+# `__all__` lists only the names that are intentionally part of the public
+# API and are eagerly available after `from multimodalhugs.data import *`.
+# The six dataset builder classes (Pose2TextDataset, Video2TextDataset, …)
+# are deliberately excluded: they are loaded lazily via __getattr__ below so
+# that importing this package does not require their optional dependencies.
+__all__ = [
+    # dataset config / collator
+    "MultimodalDataConfig",
+    "DataCollatorMultimodalSeq2Seq",
+    # utilities re-exported from .utils
+    "BICUBIC",
+    "string_to_list",
+    "pad_and_create_mask",
+    "center_image_on_white_background",
+    "grayscale_image",
+    "resize_and_center_image",
+    "check_columns",
+    "contains_empty",
+    "sample_signal_exists",
+    "file_exists_filter",
+    "duration_filter",
+    "split_sentence",
+    "create_image",
+    "normalize_images",
+    "make_image_array",
+    "get_images",
+    "gather_appropriate_data_cfg",
+    "get_all_dataclass_fields",
+    "build_merged_omegaconf_config",
+    "resolve_and_update_config",
+]
+
 # Dataset classes are loaded lazily so that importing multimodalhugs (or
 # multimodalhugs.data) does not execute modality-specific dataset modules —
 # and therefore does not require their optional dependencies — unless that

--- a/multimodalhugs/data/datasets/features2text.py
+++ b/multimodalhugs/data/datasets/features2text.py
@@ -5,7 +5,6 @@ import datasets
 import numpy as np
 
 from pathlib import Path
-from pose_format import Pose
 from typing import Any, Union, Dict, Optional
 from datasets import load_dataset, Dataset, DatasetInfo, SplitGenerator, Features
 from dataclasses import dataclass, field

--- a/multimodalhugs/data/datasets/pose2text.py
+++ b/multimodalhugs/data/datasets/pose2text.py
@@ -4,8 +4,12 @@ import torch
 import datasets
 
 from pathlib import Path
-from pose_format import Pose
-from pose_format.pose_body import EmptyPoseBody
+try:
+    from pose_format import Pose
+    from pose_format.pose_body import EmptyPoseBody
+    _POSE_FORMAT_AVAILABLE = True
+except ImportError:
+    _POSE_FORMAT_AVAILABLE = False
 from typing import Any, Union, Dict, Optional
 from datasets import load_dataset, Dataset, DatasetInfo, SplitGenerator, Features
 from dataclasses import dataclass, field
@@ -101,6 +105,11 @@ class Pose2TextDataset(datasets.GeneratorBasedBuilder):
 
         If both are provided, keyword arguments take priority.
         """
+        if not _POSE_FORMAT_AVAILABLE:
+            raise ImportError(
+                "Pose2TextDataset requires 'pose-format'. "
+                "Install it with: pip install pose-format"
+            )
         config, kwargs = resolve_and_update_config(Pose2TextDataConfig, config, kwargs)
         dataset_info = DatasetInfo(description="Dataset class for Pose2Text.")
         super().__init__(info=dataset_info, *args, **kwargs)

--- a/multimodalhugs/data/datasets/pose2text.py
+++ b/multimodalhugs/data/datasets/pose2text.py
@@ -108,7 +108,7 @@ class Pose2TextDataset(datasets.GeneratorBasedBuilder):
         if not _POSE_FORMAT_AVAILABLE:
             raise ImportError(
                 "Pose2TextDataset requires 'pose-format'. "
-                "Install it with: pip install pose-format"
+                'Install it with: pip install pose-format  or  pip install "multimodalhugs[pose]"'
             )
         config, kwargs = resolve_and_update_config(Pose2TextDataConfig, config, kwargs)
         dataset_info = DatasetInfo(description="Dataset class for Pose2Text.")

--- a/multimodalhugs/data/datasets/signwriting.py
+++ b/multimodalhugs/data/datasets/signwriting.py
@@ -6,7 +6,11 @@ from pathlib import Path
 from typing import Any, Union, Dict, Optional
 from datasets import load_dataset, Dataset, DatasetInfo, SplitGenerator, Features
 
-from signwriting.tokenizer import normalize_signwriting
+try:
+    from signwriting.tokenizer import normalize_signwriting
+    _SIGNWRITING_AVAILABLE = True
+except ImportError:
+    _SIGNWRITING_AVAILABLE = False
 from multimodalhugs.data import (
     MultimodalDataConfig,
     check_columns,
@@ -49,6 +53,11 @@ class SignWritingDataset(datasets.GeneratorBasedBuilder):
 
         If both are provided, keyword arguments take priority.
         """
+        if not _SIGNWRITING_AVAILABLE:
+            raise ImportError(
+                "SignWritingDataset requires the 'signwriting' package. "
+                "Install it with: pip install signwriting"
+            )
         config, kwargs = resolve_and_update_config(MultimodalDataConfig, config, kwargs)
         dataset_info = DatasetInfo(description="Custom dataset for SignWriting")
         super().__init__(info=dataset_info, *args, **kwargs)

--- a/multimodalhugs/data/datasets/signwriting.py
+++ b/multimodalhugs/data/datasets/signwriting.py
@@ -56,7 +56,7 @@ class SignWritingDataset(datasets.GeneratorBasedBuilder):
         if not _SIGNWRITING_AVAILABLE:
             raise ImportError(
                 "SignWritingDataset requires the 'signwriting' package. "
-                "Install it with: pip install signwriting"
+                'Install it with: pip install signwriting  or  pip install "multimodalhugs[signwriting]"'
             )
         config, kwargs = resolve_and_update_config(MultimodalDataConfig, config, kwargs)
         dataset_info = DatasetInfo(description="Custom dataset for SignWriting")

--- a/multimodalhugs/data/datasets/video2text.py
+++ b/multimodalhugs/data/datasets/video2text.py
@@ -83,7 +83,7 @@ class Video2TextDataset(datasets.GeneratorBasedBuilder):
             missing = [p for p, ok in [("av", _AV_AVAILABLE), ("torchvision", _TORCHVISION_AVAILABLE)] if not ok]
             raise ImportError(
                 f"Video2TextDataset requires: {', '.join(missing)}. "
-                f"Install with: pip install {' '.join(missing)}"
+                f'Install with: pip install {" ".join(missing)}  or  pip install "multimodalhugs[video]"'
             )
         config, kwargs = resolve_and_update_config(Video2TextDataConfig, config, kwargs)
         dataset_info = DatasetInfo(description="Dataset class for Video2Text.")

--- a/multimodalhugs/data/datasets/video2text.py
+++ b/multimodalhugs/data/datasets/video2text.py
@@ -1,5 +1,4 @@
 import os
-import av
 import torch
 import datasets
 from pathlib import Path
@@ -7,7 +6,17 @@ from omegaconf import ListConfig
 from typing import Any, Union, Optional, Dict, Tuple
 from dataclasses import dataclass, field
 
-from torchvision.io import read_video
+try:
+    import av
+    _AV_AVAILABLE = True
+except ImportError:
+    _AV_AVAILABLE = False
+
+try:
+    from torchvision.io import read_video
+    _TORCHVISION_AVAILABLE = True
+except ImportError:
+    _TORCHVISION_AVAILABLE = False
 from datasets import DatasetInfo, SplitGenerator
 from datasets import load_dataset
 
@@ -70,6 +79,12 @@ class Video2TextDataset(datasets.GeneratorBasedBuilder):
 
         If both are provided, keyword arguments take priority.
         """
+        if not _AV_AVAILABLE or not _TORCHVISION_AVAILABLE:
+            missing = [p for p, ok in [("av", _AV_AVAILABLE), ("torchvision", _TORCHVISION_AVAILABLE)] if not ok]
+            raise ImportError(
+                f"Video2TextDataset requires: {', '.join(missing)}. "
+                "Install them with: pip install av torchvision"
+            )
         config, kwargs = resolve_and_update_config(Video2TextDataConfig, config, kwargs)
         dataset_info = DatasetInfo(description="Dataset class for Video2Text.")
         super().__init__(info=dataset_info, *args, **kwargs)

--- a/multimodalhugs/data/datasets/video2text.py
+++ b/multimodalhugs/data/datasets/video2text.py
@@ -83,7 +83,7 @@ class Video2TextDataset(datasets.GeneratorBasedBuilder):
             missing = [p for p, ok in [("av", _AV_AVAILABLE), ("torchvision", _TORCHVISION_AVAILABLE)] if not ok]
             raise ImportError(
                 f"Video2TextDataset requires: {', '.join(missing)}. "
-                "Install them with: pip install av torchvision"
+                f"Install with: pip install {' '.join(missing)}"
             )
         config, kwargs = resolve_and_update_config(Video2TextDataConfig, config, kwargs)
         dataset_info = DatasetInfo(description="Dataset class for Video2Text.")

--- a/multimodalhugs/data/utils.py
+++ b/multimodalhugs/data/utils.py
@@ -21,11 +21,19 @@ try:
         BICUBIC = Image.BICUBIC
     _TORCHVISION_AVAILABLE = True
 except ImportError:
+    # Restore the safe fallback so that `BICUBIC` and `_TORCHVISION_AVAILABLE`
+    # are always defined at module level, even without torchvision installed.
+    BICUBIC = Image.BICUBIC
     _TORCHVISION_AVAILABLE = False
 
 
 def _transform(n_px, mean: List[float] = [0.48145466, 0.4578275, 0.40821073],
                std: List[float] = [0.26862954, 0.26130258, 0.27577711]):
+    if not _TORCHVISION_AVAILABLE:
+        raise ImportError(
+            "_transform requires 'torchvision'. "
+            "Install it with: pip install torchvision"
+        )
     mean = tuple(mean)
     std = tuple(std)
     return Compose([

--- a/multimodalhugs/data/utils.py
+++ b/multimodalhugs/data/utils.py
@@ -32,7 +32,7 @@ def _transform(n_px, mean: List[float] = [0.48145466, 0.4578275, 0.40821073],
     if not _TORCHVISION_AVAILABLE:
         raise ImportError(
             "_transform requires 'torchvision'. "
-            "Install it with: pip install torchvision"
+            'Install it with: pip install torchvision  or  pip install "multimodalhugs[video]"'
         )
     mean = tuple(mean)
     std = tuple(std)

--- a/multimodalhugs/data/utils.py
+++ b/multimodalhugs/data/utils.py
@@ -12,13 +12,16 @@ from types import SimpleNamespace
 from typing import List, Any, Dict, Type, Optional, Set, Tuple
 from PIL import Image, ImageOps, ImageDraw, ImageFont
 from dataclasses import fields, is_dataclass
-from torchvision.transforms import Compose, Resize, CenterCrop, ToTensor, Normalize
-
 try:
-    from torchvision.transforms import InterpolationMode
-    BICUBIC = InterpolationMode.BICUBIC
+    from torchvision.transforms import Compose, Resize, CenterCrop, ToTensor, Normalize
+    try:
+        from torchvision.transforms import InterpolationMode
+        BICUBIC = InterpolationMode.BICUBIC
+    except ImportError:
+        BICUBIC = Image.BICUBIC
+    _TORCHVISION_AVAILABLE = True
 except ImportError:
-    BICUBIC = Image.BICUBIC
+    _TORCHVISION_AVAILABLE = False
 
 
 def _transform(n_px, mean: List[float] = [0.48145466, 0.4578275, 0.40821073],

--- a/multimodalhugs/processors/image_modality_processor.py
+++ b/multimodalhugs/processors/image_modality_processor.py
@@ -3,9 +3,14 @@ import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
-import cv2
 import numpy as np
 import torch
+
+try:
+    import cv2
+    _CV2_AVAILABLE = True
+except ImportError:
+    _CV2_AVAILABLE = False
 
 from multimodalhugs.data import pad_and_create_mask, get_images, string_to_list
 from multimodalhugs.processors.modality_processor import ModalityProcessor, ProcessBatchOutput
@@ -57,6 +62,11 @@ class ImageModalityProcessor(ModalityProcessor):
                 floats or a comma-separated string.
                 Required when ``normalize_image=True``.
         """
+        if not _CV2_AVAILABLE:
+            raise ImportError(
+                "ImageModalityProcessor requires 'opencv-python'. "
+                "Install it with: pip install opencv-python"
+            )
         if normalize_image and (mean is None or std is None):
             raise ValueError(
                 "Normalization is enabled (normalize_image=True), but 'mean' and/or 'std' "

--- a/multimodalhugs/processors/image_modality_processor.py
+++ b/multimodalhugs/processors/image_modality_processor.py
@@ -65,7 +65,7 @@ class ImageModalityProcessor(ModalityProcessor):
         if not _CV2_AVAILABLE:
             raise ImportError(
                 "ImageModalityProcessor requires 'opencv-python'. "
-                "Install it with: pip install opencv-python"
+                'Install it with: pip install opencv-python  or  pip install "multimodalhugs[image]"'
             )
         if normalize_image and (mean is None or std is None):
             raise ValueError(

--- a/multimodalhugs/processors/pose_modality_processor.py
+++ b/multimodalhugs/processors/pose_modality_processor.py
@@ -3,8 +3,12 @@ from typing import Any, Dict, List, Optional, Union
 
 import torch
 
-from pose_format import Pose
-from pose_format.utils.generic import reduce_holistic, pose_hide_legs
+try:
+    from pose_format import Pose
+    from pose_format.utils.generic import reduce_holistic, pose_hide_legs
+    _POSE_FORMAT_AVAILABLE = True
+except ImportError:
+    _POSE_FORMAT_AVAILABLE = False
 
 from multimodalhugs.data import pad_and_create_mask
 from multimodalhugs.processors.modality_processor import ModalityProcessor, ProcessBatchOutput
@@ -35,6 +39,11 @@ class PoseModalityProcessor(ModalityProcessor):
                 temporal axis after loading (e.g. 2 → halve frame rate).
                 None disables downsampling. Default: None.
         """
+        if not _POSE_FORMAT_AVAILABLE:
+            raise ImportError(
+                "PoseModalityProcessor requires 'pose-format'. "
+                "Install it with: pip install pose-format"
+            )
         self.reduce_holistic_poses = reduce_holistic_poses
         self.skip_frames_stride = skip_frames_stride
 

--- a/multimodalhugs/processors/pose_modality_processor.py
+++ b/multimodalhugs/processors/pose_modality_processor.py
@@ -42,7 +42,7 @@ class PoseModalityProcessor(ModalityProcessor):
         if not _POSE_FORMAT_AVAILABLE:
             raise ImportError(
                 "PoseModalityProcessor requires 'pose-format'. "
-                "Install it with: pip install pose-format"
+                'Install it with: pip install pose-format  or  pip install "multimodalhugs[pose]"'
             )
         self.reduce_holistic_poses = reduce_holistic_poses
         self.skip_frames_stride = skip_frames_stride

--- a/multimodalhugs/processors/signwriting_modality_processor.py
+++ b/multimodalhugs/processors/signwriting_modality_processor.py
@@ -5,8 +5,12 @@ import torch
 from PIL import ImageOps
 from transformers import AutoProcessor
 
-from signwriting.tokenizer import normalize_signwriting
-from signwriting.visualizer.visualize import signwriting_to_image
+try:
+    from signwriting.tokenizer import normalize_signwriting
+    from signwriting.visualizer.visualize import signwriting_to_image
+    _SIGNWRITING_AVAILABLE = True
+except ImportError:
+    _SIGNWRITING_AVAILABLE = False
 
 from multimodalhugs.data import pad_and_create_mask, center_image_on_white_background
 from multimodalhugs.processors.modality_processor import ModalityProcessor, ProcessBatchOutput
@@ -50,6 +54,11 @@ class SignwritingModalityProcessor(ModalityProcessor):
                 image (black symbols on white → white symbols on black).
                 Default: True.
         """
+        if not _SIGNWRITING_AVAILABLE:
+            raise ImportError(
+                "SignwritingModalityProcessor requires the 'signwriting' package. "
+                "Install it with: pip install signwriting"
+            )
         if custom_preprocessor_path is None:
             raise ValueError(
                 "SignwritingModalityProcessor requires a 'custom_preprocessor_path' "

--- a/multimodalhugs/processors/signwriting_modality_processor.py
+++ b/multimodalhugs/processors/signwriting_modality_processor.py
@@ -57,7 +57,7 @@ class SignwritingModalityProcessor(ModalityProcessor):
         if not _SIGNWRITING_AVAILABLE:
             raise ImportError(
                 "SignwritingModalityProcessor requires the 'signwriting' package. "
-                "Install it with: pip install signwriting"
+                'Install it with: pip install signwriting  or  pip install "multimodalhugs[signwriting]"'
             )
         if custom_preprocessor_path is None:
             raise ValueError(

--- a/multimodalhugs/processors/video_modality_processor.py
+++ b/multimodalhugs/processors/video_modality_processor.py
@@ -71,12 +71,12 @@ class VideoModalityProcessor(ModalityProcessor):
         if custom_preprocessor_path is not None and not _CV2_AVAILABLE:
             raise ImportError(
                 "VideoModalityProcessor with a custom_preprocessor_path requires 'opencv-python'. "
-                "Install it with: pip install opencv-python"
+                'Install it with: pip install opencv-python  or  pip install "multimodalhugs[video]"'
             )
         if custom_preprocessor_path is None and not _TORCHVISION_AVAILABLE:
             raise ImportError(
                 "VideoModalityProcessor requires 'torchvision'. "
-                "Install it with: pip install torchvision"
+                'Install it with: pip install torchvision  or  pip install "multimodalhugs[video]"'
             )
         self.custom_preprocessor_path = custom_preprocessor_path
         self.skip_frames_stride = skip_frames_stride

--- a/multimodalhugs/processors/video_modality_processor.py
+++ b/multimodalhugs/processors/video_modality_processor.py
@@ -4,12 +4,22 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
-import cv2
 import numpy as np
 import torch
 from PIL import Image
-from torchvision.io import read_video
 from transformers import AutoProcessor
+
+try:
+    import cv2
+    _CV2_AVAILABLE = True
+except ImportError:
+    _CV2_AVAILABLE = False
+
+try:
+    from torchvision.io import read_video
+    _TORCHVISION_AVAILABLE = True
+except ImportError:
+    _TORCHVISION_AVAILABLE = False
 
 from multimodalhugs.data import pad_and_create_mask
 from multimodalhugs.processors.modality_processor import ModalityProcessor, ProcessBatchOutput
@@ -58,6 +68,16 @@ class VideoModalityProcessor(ModalityProcessor):
                 (1 s, 2 s, 4 s, …) to tolerate transient NFS slowness on
                 shared clusters. Default: 3.
         """
+        if custom_preprocessor_path is not None and not _CV2_AVAILABLE:
+            raise ImportError(
+                "VideoModalityProcessor with a custom_preprocessor_path requires 'opencv-python'. "
+                "Install it with: pip install opencv-python"
+            )
+        if custom_preprocessor_path is None and not _TORCHVISION_AVAILABLE:
+            raise ImportError(
+                "VideoModalityProcessor requires 'torchvision'. "
+                "Install it with: pip install torchvision"
+            )
         self.custom_preprocessor_path = custom_preprocessor_path
         self.skip_frames_stride = skip_frames_stride
         self.join_chw = join_chw

--- a/multimodalhugs/tasks/translation/translation_generate.py
+++ b/multimodalhugs/tasks/translation/translation_generate.py
@@ -36,7 +36,6 @@ import argparse
 import warnings
 
 import datasets
-import evaluate
 import numpy as np
 from datasets import load_from_disk
 
@@ -251,6 +250,7 @@ def main():
         )
 
     # --- Load the evaluation metric ---
+    import evaluate
     metric = evaluate.load(training_args.metric_name, cache_dir=model_args.cache_dir)
     training_args.generation_config = generation_config if generation_config is not None else None
 

--- a/multimodalhugs/tasks/translation/translation_generate.py
+++ b/multimodalhugs/tasks/translation/translation_generate.py
@@ -250,6 +250,15 @@ def main():
         )
 
     # --- Load the evaluation metric ---
+    # `import evaluate` is deferred here rather than placed at the top of the
+    # file. `evaluate` transitively imports `transformers.pipelines` (including
+    # `video_classification`), which in turn imports `av`. A top-level import
+    # would therefore require `av` in every environment just to *load* this
+    # module, even in pose-only or text-only setups that never call this script.
+    # NOTE: `multimodalhugs/__init__.py` no longer does `from .tasks import *`,
+    # so the transitive chain is already broken at that level. This deferred
+    # import is kept as an extra layer of defence in case the import path
+    # changes in the future.
     import evaluate
     metric = evaluate.load(training_args.metric_name, cache_dir=model_args.cache_dir)
     training_args.generation_config = generation_config if generation_config is not None else None

--- a/multimodalhugs/tasks/translation/translation_generate.py
+++ b/multimodalhugs/tasks/translation/translation_generate.py
@@ -250,17 +250,17 @@ def main():
         )
 
     # --- Load the evaluation metric ---
-    # `import evaluate` is deferred here rather than placed at the top of the
-    # file. `evaluate` transitively imports `transformers.pipelines` (including
-    # `video_classification`), which in turn imports `av`. A top-level import
-    # would therefore require `av` in every environment just to *load* this
-    # module, even in pose-only or text-only setups that never call this script.
-    # NOTE: `multimodalhugs/__init__.py` no longer does `from .tasks import *`,
-    # so the transitive chain is already broken at that level. This deferred
-    # import is kept as an extra layer of defence in case the import path
-    # changes in the future.
-    import evaluate
-    metric = evaluate.load(training_args.metric_name, cache_dir=model_args.cache_dir)
+    # `import evaluate` is deferred here and made conditional on `metric_name`
+    # being set. `evaluate` transitively imports `transformers.pipelines`
+    # (including `video_classification`), which in turn imports `av`. A
+    # top-level import would therefore require `av` in every environment just
+    # to *load* this module, even in pose-only or text-only setups that never
+    # use a metric. Keeping the import conditional means environments without
+    # `av` can still run generation as long as no metric is requested.
+    metric = None
+    if training_args.metric_name is not None:
+        import evaluate
+        metric = evaluate.load(training_args.metric_name, cache_dir=model_args.cache_dir)
     training_args.generation_config = generation_config if generation_config is not None else None
 
     if generate_args.generate_output_dir is not None: # HOTFIX to ensure the trainer stores all_results.json at generate_output_dir directory
@@ -273,7 +273,7 @@ def main():
         tokenizer=tokenizer,
         data_collator=data_collator,
         compute_metrics=lambda eval_preds: compute_metrics(eval_preds, tokenizer, metric)
-            if training_args.predict_with_generate else None,
+            if training_args.predict_with_generate and metric is not None else None,
         visualize_prediction_prob=training_args.visualize_prediction_prob
     )
 

--- a/multimodalhugs/tasks/translation/translation_training.py
+++ b/multimodalhugs/tasks/translation/translation_training.py
@@ -262,6 +262,11 @@ def main():
         )
     
     # Load metric(s)
+    # `import evaluate` is deferred here because `evaluate` transitively imports
+    # `transformers.pipelines` (including `video_classification`), which imports
+    # `av`. A top-level import would force `av` to be installed in every
+    # environment even when training without a metric. Deferring keeps the
+    # dependency conditional on `metric_name` actually being set.
     if training_args.metric_name is not None:
         import evaluate
         metric_names = [m.strip() for m in training_args.metric_name.split(",")]

--- a/multimodalhugs/tasks/translation/translation_training.py
+++ b/multimodalhugs/tasks/translation/translation_training.py
@@ -28,7 +28,6 @@ import argparse
 import warnings
 
 import datasets
-import evaluate
 import numpy as np
 from datasets import load_from_disk
 
@@ -264,6 +263,7 @@ def main():
     
     # Load metric(s)
     if training_args.metric_name is not None:
+        import evaluate
         metric_names = [m.strip() for m in training_args.metric_name.split(",")]
         metrics_list = [evaluate.load(name, cache_dir=model_args.cache_dir) for name in metric_names]
 

--- a/multimodalhugs/training_setup/general_training_setup.py
+++ b/multimodalhugs/training_setup/general_training_setup.py
@@ -45,44 +45,63 @@ logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Dataset type → (DatasetClass, DataConfigClass) lookup table.
+# Dataset type → lazy import spec.
 #
-# Keys must match the registry keys used by @register_dataset and the value
-# users write in data.dataset_type in their YAML config.
-#
-# Imports are deferred inside the function to avoid circular import issues at
-# module load time.
+# Each entry maps a dataset_type string to a (module_path, class_names) tuple
+# where class_names is (DatasetClassName, DataConfigClassName).  The actual
+# import only happens when the specific dataset_type is requested, so running
+# setup for one modality never imports optional dependencies of another.
 # ---------------------------------------------------------------------------
 
-def _build_dataset_map() -> dict:
-    """Return the mapping from dataset_type string to (DatasetClass, DataConfigClass)."""
-    from multimodalhugs.data.datasets.pose2text import (
-        Pose2TextDataset, Pose2TextDataConfig,
-    )
-    from multimodalhugs.data.datasets.video2text import (
-        Video2TextDataset, Video2TextDataConfig,
-    )
-    from multimodalhugs.data.datasets.features2text import (
-        Features2TextDataset, Features2TextDataConfig,
-    )
-    from multimodalhugs.data.datasets.signwriting import SignWritingDataset
-    from multimodalhugs.data.dataset_configs.multimodal_mt_data_config import MultimodalDataConfig
-    from multimodalhugs.data.datasets.bilingual_image2text import (
-        BilingualImage2TextDataset, BilingualImage2textMTDataConfig,
-    )
-    from multimodalhugs.data.datasets.bilingual_text2text import (
-        BilingualText2TextDataset, BilingualText2textMTDataConfig,
-    )
-
-    return {
-        "pose2text":        (Pose2TextDataset,          Pose2TextDataConfig),
-        "video2text":       (Video2TextDataset,          Video2TextDataConfig),
-        "features2text":    (Features2TextDataset,       Features2TextDataConfig),
+_DATASET_IMPORT_MAP: dict = {
+    "pose2text": (
+        "multimodalhugs.data.datasets.pose2text",
+        ("Pose2TextDataset", "Pose2TextDataConfig"),
+    ),
+    "video2text": (
+        "multimodalhugs.data.datasets.video2text",
+        ("Video2TextDataset", "Video2TextDataConfig"),
+    ),
+    "features2text": (
+        "multimodalhugs.data.datasets.features2text",
+        ("Features2TextDataset", "Features2TextDataConfig"),
+    ),
+    "signwriting2text": (
+        "multimodalhugs.data.datasets.signwriting",
         # SignWritingDataset uses the base MultimodalDataConfig (no subclass needed).
-        "signwriting2text": (SignWritingDataset,         MultimodalDataConfig),
-        "image2text":       (BilingualImage2TextDataset, BilingualImage2textMTDataConfig),
-        "text2text":        (BilingualText2TextDataset,  BilingualText2textMTDataConfig),
-    }
+        ("SignWritingDataset", None),
+    ),
+    "image2text": (
+        "multimodalhugs.data.datasets.bilingual_image2text",
+        ("BilingualImage2TextDataset", "BilingualImage2textMTDataConfig"),
+    ),
+    "text2text": (
+        "multimodalhugs.data.datasets.bilingual_text2text",
+        ("BilingualText2TextDataset", "BilingualText2textMTDataConfig"),
+    ),
+}
+
+
+def _load_dataset_classes(dataset_type: str):
+    """Import and return (DatasetClass, DataConfigClass) for the given dataset_type."""
+    import importlib
+    from multimodalhugs.data.dataset_configs.multimodal_mt_data_config import MultimodalDataConfig
+
+    module_path, (dataset_cls_name, config_cls_name) = _DATASET_IMPORT_MAP[dataset_type]
+    module = importlib.import_module(module_path)
+    DatasetClass = getattr(module, dataset_cls_name)
+    DataConfigClass = getattr(module, config_cls_name) if config_cls_name else MultimodalDataConfig
+    return DatasetClass, DataConfigClass
+
+
+def _build_dataset_map() -> dict:
+    """Return the full mapping from dataset_type string to (DatasetClass, DataConfigClass).
+
+    Imports each dataset module on demand so that optional dependencies for
+    unused modalities are never required.  Kept as a public helper for tests
+    and tooling that need to inspect the complete map at once.
+    """
+    return {dtype: _load_dataset_classes(dtype) for dtype in _DATASET_IMPORT_MAP}
 
 
 def main(
@@ -147,17 +166,16 @@ def main(
             raise ValueError(
                 "data.dataset_type is required for the general setup path. "
                 "Add 'dataset_type: <type>' under the 'data:' section of your config. "
-                f"Supported values: {sorted(_build_dataset_map())}."
+                f"Supported values: {sorted(_DATASET_IMPORT_MAP)}."
             )
 
-        dataset_map = _build_dataset_map()
-        if dataset_type not in dataset_map:
+        if dataset_type not in _DATASET_IMPORT_MAP:
             raise ValueError(
                 f"Unknown data.dataset_type: '{dataset_type}'. "
-                f"Supported values: {sorted(dataset_map)}."
+                f"Supported values: {sorted(_DATASET_IMPORT_MAP)}."
             )
 
-        DatasetClass, DataConfigClass = dataset_map[dataset_type]
+        DatasetClass, DataConfigClass = _load_dataset_classes(dataset_type)
         data_cfg = DataConfigClass(cfg)
         data_path = prepare_dataset(
             DatasetClass,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "multimodalhugs"
 description = "MultimodalHugs is an extension of Hugging Face that offers a generalized framework for training, evaluating, and using multimodal AI models with minimal code differences, ensuring seamless compatibility with Hugging Face pipelines."
-version = "0.5.0"
+version = "0.5.1"
 authors = [
     { name = "Gerard Sant", email = "gerard.santmuniesa@uzh.ch" },
     { name = "Zifan Jiang" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,9 @@ readme = "README.md"
 dependencies = [
     "datasets",
     "torch<2.6", # Currently, HuggingFace does not support changing the default value of the `weights_only` argument in `torch.load` from `False` to `True` introduced in PyTorch 2.6.
-    "torchvision",
     "torchaudio",
     "transformers<=4.44.2",
     "accelerate",
-    "opencv-python",
     "librosa",
     "numpy",
     "scipy",
@@ -33,14 +31,31 @@ dependencies = [
     "jiwer",
     "Pillow",
     "evaluate",
-    "signwriting @ git+https://github.com/sign-language-processing/signwriting",
-    "pose-format>=0.10.1",
     "ruamel.yaml",
-    "av>=10.0.0",
     "tf-keras",
 ]
 
 [project.optional-dependencies]
+pose = [
+    "pose-format>=0.10.1",
+]
+video = [
+    "av>=10.0.0",
+    "torchvision",
+    "opencv-python",
+]
+signwriting = [
+    "signwriting @ git+https://github.com/sign-language-processing/signwriting",
+]
+image = [
+    "opencv-python",
+]
+full = [
+    "multimodalhugs[pose]",
+    "multimodalhugs[video]",
+    "multimodalhugs[signwriting]",
+    "multimodalhugs[image]",
+]
 dev = [
     "pytest",
     "pylint",

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -806,6 +806,8 @@ Tests that each modality processor and dataset raises a clear `ImportError` (men
 | `test_pose2text_dataset_raises_without_pose_format` | `Pose2TextDataset()` raises `ImportError` mentioning `pose-format` when `_POSE_FORMAT_AVAILABLE=False` |
 | `test_signwriting_dataset_raises_without_signwriting` | `SignWritingDataset()` raises `ImportError` mentioning `signwriting` when `_SIGNWRITING_AVAILABLE=False` |
 | `test_video2text_dataset_raises_without_av` | `Video2TextDataset()` raises `ImportError` mentioning `av` when `_AV_AVAILABLE=False` |
+| `test_video2text_dataset_raises_without_torchvision` | `Video2TextDataset()` raises `ImportError` mentioning `torchvision` when `_TORCHVISION_AVAILABLE=False` |
+| `test_video_processor_no_raise_without_cv2_when_no_custom_preprocessor` | `VideoModalityProcessor(custom_preprocessor_path=None)` does **not** raise when `_CV2_AVAILABLE=False`; cv2 is only required when a custom preprocessor path is provided |
 
 ---
 

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -785,6 +785,30 @@ Tests for `build_processor_from_config()` and `expand_pipeline_shorthand()` in `
 
 ---
 
+### `test_optional_import_guards.py`
+
+Tests that each modality processor and dataset raises a clear `ImportError` (mentioning the missing package) when its optional dependency is absent. Module-level `_*_AVAILABLE` flags are patched via `monkeypatch` to simulate a missing package without uninstalling anything.
+
+**Processors**
+
+| Test | What it checks |
+|---|---|
+| `test_pose_processor_raises_without_pose_format` | `PoseModalityProcessor()` raises `ImportError` mentioning `pose-format` when `_POSE_FORMAT_AVAILABLE=False` |
+| `test_signwriting_processor_raises_without_signwriting` | `SignwritingModalityProcessor()` raises `ImportError` mentioning `signwriting` when `_SIGNWRITING_AVAILABLE=False` |
+| `test_video_processor_raises_without_cv2_when_custom_preprocessor` | `VideoModalityProcessor(custom_preprocessor_path=...)` raises `ImportError` mentioning `opencv-python` when `_CV2_AVAILABLE=False` |
+| `test_video_processor_raises_without_torchvision` | `VideoModalityProcessor()` raises `ImportError` mentioning `torchvision` when `_TORCHVISION_AVAILABLE=False` |
+| `test_image_processor_raises_without_cv2` | `ImageModalityProcessor()` raises `ImportError` mentioning `opencv-python` when `_CV2_AVAILABLE=False` |
+
+**Datasets**
+
+| Test | What it checks |
+|---|---|
+| `test_pose2text_dataset_raises_without_pose_format` | `Pose2TextDataset()` raises `ImportError` mentioning `pose-format` when `_POSE_FORMAT_AVAILABLE=False` |
+| `test_signwriting_dataset_raises_without_signwriting` | `SignWritingDataset()` raises `ImportError` mentioning `signwriting` when `_SIGNWRITING_AVAILABLE=False` |
+| `test_video2text_dataset_raises_without_av` | `Video2TextDataset()` raises `ImportError` mentioning `av` when `_AV_AVAILABLE=False` |
+
+---
+
 ### `test_processor_regression.py`
 
 Regression tests comparing processor output against golden files in `tests/assets/golden/`. Golden files capture shape, dtype, mean, std, min, max, sum, and first/last 8 values of every output tensor. To regenerate: `python tests/assets/generate_golden.py`.

--- a/tests/test_data/conftest.py
+++ b/tests/test_data/conftest.py
@@ -3,7 +3,12 @@
 import os
 import random
 
-import av
+try:
+    import av
+    _AV_AVAILABLE = True
+except ImportError:
+    _AV_AVAILABLE = False
+
 import numpy as np
 import pytest
 import torch
@@ -76,6 +81,8 @@ def dummy_pose_file(tmp_path):
 @pytest.fixture
 def dummy_video_file(tmp_path):
     """Create a minimal 10-frame 64x64 MPEG4 video."""
+    if not _AV_AVAILABLE:
+        pytest.skip("av not installed")
     path = str(tmp_path / "dummy.mp4")
     container = av.open(path, mode="w")
     stream = container.add_stream("mpeg4", rate=25)

--- a/tests/test_data/test_optional_import_guards.py
+++ b/tests/test_data/test_optional_import_guards.py
@@ -74,3 +74,16 @@ def test_video2text_dataset_raises_without_av(monkeypatch):
     monkeypatch.setattr(video2text_mod, "_AV_AVAILABLE", False)
     with pytest.raises(ImportError, match="av"):
         video2text_mod.Video2TextDataset()
+
+
+def test_video2text_dataset_raises_without_torchvision(monkeypatch):
+    monkeypatch.setattr(video2text_mod, "_TORCHVISION_AVAILABLE", False)
+    with pytest.raises(ImportError, match="torchvision"):
+        video2text_mod.Video2TextDataset()
+
+
+def test_video_processor_no_raise_without_cv2_when_no_custom_preprocessor(monkeypatch):
+    monkeypatch.setattr(video_mod, "_CV2_AVAILABLE", False)
+    # cv2 is only required when custom_preprocessor_path is set; without it the
+    # processor should instantiate without error even if cv2 is absent.
+    video_mod.VideoModalityProcessor(custom_preprocessor_path=None)

--- a/tests/test_data/test_optional_import_guards.py
+++ b/tests/test_data/test_optional_import_guards.py
@@ -1,0 +1,76 @@
+"""
+Tests that each modality processor and dataset raises a clear ImportError
+(mentioning the missing package name) when its optional dependency is absent.
+
+The module-level availability flags (_*_AVAILABLE) are patched via monkeypatch
+rather than manipulating sys.modules, because packages such as av, cv2, and
+torchvision are also used internally by transformers — blocking them at the
+import level would crash the entire package init chain before reaching the code
+under test.  Patching the flags directly tests the exact guard logic added to
+each __init__ method, which is the behaviour this fix introduces.
+"""
+import pytest
+
+import multimodalhugs.data.datasets.pose2text as pose2text_mod
+import multimodalhugs.data.datasets.signwriting as sw_dataset_mod
+import multimodalhugs.data.datasets.video2text as video2text_mod
+import multimodalhugs.processors.image_modality_processor as img_mod
+import multimodalhugs.processors.pose_modality_processor as pose_mod
+import multimodalhugs.processors.signwriting_modality_processor as sw_mod
+import multimodalhugs.processors.video_modality_processor as video_mod
+
+
+# ---------------------------------------------------------------------------
+# Processors
+# ---------------------------------------------------------------------------
+
+def test_pose_processor_raises_without_pose_format(monkeypatch):
+    monkeypatch.setattr(pose_mod, "_POSE_FORMAT_AVAILABLE", False)
+    with pytest.raises(ImportError, match="pose-format"):
+        pose_mod.PoseModalityProcessor()
+
+
+def test_signwriting_processor_raises_without_signwriting(monkeypatch):
+    monkeypatch.setattr(sw_mod, "_SIGNWRITING_AVAILABLE", False)
+    with pytest.raises(ImportError, match="signwriting"):
+        sw_mod.SignwritingModalityProcessor(custom_preprocessor_path="dummy")
+
+
+def test_video_processor_raises_without_cv2_when_custom_preprocessor(monkeypatch):
+    monkeypatch.setattr(video_mod, "_CV2_AVAILABLE", False)
+    with pytest.raises(ImportError, match="opencv-python"):
+        video_mod.VideoModalityProcessor(custom_preprocessor_path="dummy")
+
+
+def test_video_processor_raises_without_torchvision(monkeypatch):
+    monkeypatch.setattr(video_mod, "_TORCHVISION_AVAILABLE", False)
+    with pytest.raises(ImportError, match="torchvision"):
+        video_mod.VideoModalityProcessor()
+
+
+def test_image_processor_raises_without_cv2(monkeypatch):
+    monkeypatch.setattr(img_mod, "_CV2_AVAILABLE", False)
+    with pytest.raises(ImportError, match="opencv-python"):
+        img_mod.ImageModalityProcessor(normalize_image=False)
+
+
+# ---------------------------------------------------------------------------
+# Datasets
+# ---------------------------------------------------------------------------
+
+def test_pose2text_dataset_raises_without_pose_format(monkeypatch):
+    monkeypatch.setattr(pose2text_mod, "_POSE_FORMAT_AVAILABLE", False)
+    with pytest.raises(ImportError, match="pose-format"):
+        pose2text_mod.Pose2TextDataset()
+
+
+def test_signwriting_dataset_raises_without_signwriting(monkeypatch):
+    monkeypatch.setattr(sw_dataset_mod, "_SIGNWRITING_AVAILABLE", False)
+    with pytest.raises(ImportError, match="signwriting"):
+        sw_dataset_mod.SignWritingDataset()
+
+
+def test_video2text_dataset_raises_without_av(monkeypatch):
+    monkeypatch.setattr(video2text_mod, "_AV_AVAILABLE", False)
+    with pytest.raises(ImportError, match="av"):
+        video2text_mod.Video2TextDataset()


### PR DESCRIPTION
## Summary

Closes #82

This PR addresses the issue that importing any part of `multimodalhugs` required all modality-specific dependencies to be installed, even for users who only need one modality (e.g. text-to-text).

### Root cause

Two compounding problems:

1. `multimodalhugs/__init__.py` had `from .tasks import *`, which transitively forced `av` and `cv2` to be imported at package load time via `evaluate → transformers.pipelines.video_classification`.
2. Modality processors and datasets imported their optional dependencies unconditionally at module level, so importing the package raised `ImportError` if any optional dep was missing.

### Changes

- **`pyproject.toml`** — Moves `pose-format`, `opencv-python`, `signwriting`, `av`, and `torchvision` out of core dependencies into modality-scoped optional extras (`[pose]`, `[video]`, `[signwriting]`, `[image]`). A `[full]` meta-extra restores the previous all-inclusive install: `pip install "multimodalhugs[full]"`.
- **`__init__.py`** — Removes `from .tasks import *` and `from .multimodalhugs_cli import *`. CLI commands are unaffected (they use `console_scripts` and bypass `__init__.py`).
- **Processors** — `PoseModalityProcessor`, `VideoModalityProcessor`, `SignwritingModalityProcessor`, `ImageModalityProcessor` now wrap optional imports in `try/except` and raise a clear `ImportError` with a `pip install` hint at instantiation time.
- **Datasets** — Same pattern applied to `Pose2TextDataset`, `SignWritingDataset`, `Video2TextDataset`.
- **`README.md`** — Installation section updated to document the new extras.
- **`CHANGELOG.md`** — 0.5.1 entry added.
- **Tests** — `tests/test_data/test_optional_import_guards.py` added with 8 monkeypatch tests verifying each guard raises the correct `ImportError`.

## Test plan

- [ ] `pytest tests/ --ignore=tests/e2e_overfitting` passes (423 tests)
- [ ] `pip install "multimodalhugs[full]"` installs all deps as before
- [ ] `pip install "multimodalhugs[pose]"` installs only `pose-format`
- [ ] Import without optional dep installed raises a clear `ImportError` with install hint