### PR TITLE
Add signal_start_end_unit to pose and video processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Each version section may have subsections for: _Added_, _Changed_, _Removed_, _D
 ### Added
 
 - **`signal_start_end_unit` parameter on `PoseModalityProcessor`, `VideoModalityProcessor`, `Pose2TextDataConfig`, and `Video2TextDataConfig`.**
-  Processors and dataset configs now accept `signal_start_end_unit` (default `SignalUnit.MILLISECONDS`, preserving the existing behaviour). Setting it to `SignalUnit.FRAMES` tells the processor to interpret `signal_start` / `signal_end` as frame indices rather than milliseconds. Plain strings `"milliseconds"` and `"frames"` are accepted for backward compatibility.
+  Processors and dataset configs now accept `signal_start_end_unit` (default `SignalUnit.MILLISECONDS`, preserving the existing behaviour). Setting it to `SignalUnit.FRAMES` tells the processor to interpret `signal_start` / `signal_end` as frame indices rather than milliseconds.
 
   - **`PoseModalityProcessor`** — passes `start_frame` / `end_frame` directly to `Pose.read`, which uses a seek-capable `BytesIOReader` internally. Normalisation sees only the requested window, consistent with the milliseconds path. Raises `ValueError` at construction time for unknown unit values.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Version numbers are of the form `1.0.0`.
 
 Each version section may have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
-## [Unreleased]
+## [0.5.2]
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ Version numbers are of the form `1.0.0`.
 
 Each version section may have subsections for: _Added_, _Changed_, _Removed_, _Deprecated_, and _Fixed_.
 
+## [Unreleased]
+
+### Added
+
+- **`signal_start_end_unit` parameter on `PoseModalityProcessor` and `VideoModalityProcessor`.**
+  Both processors now accept `signal_start_end_unit: str` (default `"milliseconds"`, preserving the existing behaviour). Setting it to `"frames"` tells the processor to interpret `signal_start` / `signal_end` as frame indices rather than milliseconds:
+
+  - **`PoseModalityProcessor`** — passes `start_frame` / `end_frame` directly to `Pose.read`, which uses a seek-capable `BytesIOReader` internally. Normalisation sees only the requested window, consistent with the milliseconds path. Raises `ValueError` at construction time for any value other than `"milliseconds"` or `"frames"`.
+
+  - **`VideoModalityProcessor`** — for the OpenCV path (`custom_preprocessor_path` set), uses `CAP_PROP_POS_FRAMES` for seeking and position checking. For the torchvision path, reads the full video and slices by index (torchvision does not support frame-index seeking natively). Raises `ValueError` at construction time for unknown unit values.
+
+  - **Legacy wrappers** (`Pose2TextTranslationProcessor`, `Video2TextTranslationProcessor`) accept and forward the new parameter to their underlying modality processor unchanged.
+
+  - The zero/zero convention (`signal_start=0, signal_end=0` → full file) is preserved for both units.
+
+---
+
 ## [0.5.1]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,29 @@ Each version section may have subsections for: _Added_, _Changed_, _Removed_, _D
 
 ### Added
 
-- **`signal_start_end_unit` parameter on `PoseModalityProcessor` and `VideoModalityProcessor`.**
-  Both processors now accept `signal_start_end_unit: str` (default `"milliseconds"`, preserving the existing behaviour). Setting it to `"frames"` tells the processor to interpret `signal_start` / `signal_end` as frame indices rather than milliseconds:
+- **`signal_start_end_unit` parameter on `PoseModalityProcessor`, `VideoModalityProcessor`, `Pose2TextDataConfig`, and `Video2TextDataConfig`.**
+  Processors and dataset configs now accept `signal_start_end_unit` (default `SignalUnit.MILLISECONDS`, preserving the existing behaviour). Setting it to `SignalUnit.FRAMES` tells the processor to interpret `signal_start` / `signal_end` as frame indices rather than milliseconds. Plain strings `"milliseconds"` and `"frames"` are accepted for backward compatibility.
 
-  - **`PoseModalityProcessor`** — passes `start_frame` / `end_frame` directly to `Pose.read`, which uses a seek-capable `BytesIOReader` internally. Normalisation sees only the requested window, consistent with the milliseconds path. Raises `ValueError` at construction time for any value other than `"milliseconds"` or `"frames"`.
+  - **`PoseModalityProcessor`** — passes `start_frame` / `end_frame` directly to `Pose.read`, which uses a seek-capable `BytesIOReader` internally. Normalisation sees only the requested window, consistent with the milliseconds path. Raises `ValueError` at construction time for unknown unit values.
 
   - **`VideoModalityProcessor`** — for the OpenCV path (`custom_preprocessor_path` set), uses `CAP_PROP_POS_FRAMES` for seeking and position checking. For the torchvision path, reads the full video and slices by index (torchvision does not support frame-index seeking natively). Raises `ValueError` at construction time for unknown unit values.
+
+  - **`Pose2TextDataConfig` / `Video2TextDataConfig`** — expose the same parameter; the dataset duration-filtering logic (`mapping_function`) now respects the chosen unit when computing clip duration for `max_frames` / `min_frames` filtering.
 
   - **Legacy wrappers** (`Pose2TextTranslationProcessor`, `Video2TextTranslationProcessor`) accept and forward the new parameter to their underlying modality processor unchanged.
 
   - The zero/zero convention (`signal_start=0, signal_end=0` → full file) is preserved for both units.
+
+- **`SignalUnit` enum** (`multimodalhugs.processors.SignalUnit`).
+  A `StrEnum`-based enum (Python 3.8+ compatible) that defines the valid values for `signal_start_end_unit`:
+
+  ```python
+  from multimodalhugs.processors import SignalUnit
+
+  processor = PoseModalityProcessor(signal_start_end_unit=SignalUnit.FRAMES)
+  ```
+
+  Instances compare equal to their string values (`SignalUnit.MILLISECONDS == "milliseconds"`) and serialise as plain strings, so existing YAML configs and `save_pretrained`/`from_pretrained` round-trips are unaffected.
 
 ---
 

--- a/docs/processors/processor_config_formats.md
+++ b/docs/processors/processor_config_formats.md
@@ -235,14 +235,15 @@ Loads `.pose` files and converts them to `[T, D]` tensors (T = frames, D = keypo
 |---|---|---|---|
 | `reduce_holistic_poses` | bool | `true` | Reduce full holistic pose to a smaller set of landmarks |
 | `skip_frames_stride` | int | `null` | Keep every N-th frame (e.g. `2` = keep every other frame) |
+| `signal_start_end_unit` | str | `"milliseconds"` | Unit for `signal_start` / `signal_end`: `"milliseconds"` or `"frames"`. `0`/`0` always loads the full file regardless of unit. |
 
 **`column_map` processor param names:** `signal`, `signal_start`, `signal_end`
 
 ```yaml
 column_map:
   signal: signal             # TSV column → processor param (required)
-  signal_start: signal_start # start frame offset (optional)
-  signal_end: signal_end     # end frame offset (optional)
+  signal_start: signal_start # clip start in milliseconds by default; see signal_start_end_unit
+  signal_end: signal_end     # clip end in milliseconds by default; see signal_start_end_unit
 ```
 
 ---
@@ -259,14 +260,15 @@ Loads video files and converts them to `[T, C, H, W]` tensors (or `[T, C*H*W]` i
 | `skip_frames_stride` | int | `null` | Keep every N-th frame |
 | `join_chw` | bool | `false` | Flatten channel, height, and width dimensions into one |
 | `use_cache` | bool | `false` | Cache loaded videos in memory (speeds up repeated access) |
+| `signal_start_end_unit` | str | `"milliseconds"` | Unit for `signal_start` / `signal_end`: `"milliseconds"` or `"frames"`. `0`/`0` always loads the full file regardless of unit. |
 
 **`column_map` processor param names:** `signal`, `signal_start`, `signal_end`
 
 ```yaml
 column_map:
   signal: signal
-  signal_start: signal_start # start time in seconds
-  signal_end: signal_end     # end time in seconds
+  signal_start: signal_start # clip start in milliseconds by default; see signal_start_end_unit
+  signal_end: signal_end     # clip end in milliseconds by default; see signal_start_end_unit
 ```
 
 ---

--- a/docs/processors/processors_overview.md
+++ b/docs/processors/processors_overview.md
@@ -65,8 +65,8 @@ This means expensive I/O (reading video or pose files) is done lazily per item d
 
 | Class | Modality | Key parameters |
 |---|---|---|
-| `PoseModalityProcessor` | `.pose` files | `reduce_holistic_poses`, `skip_frames_stride` |
-| `VideoModalityProcessor` | Video files | `skip_frames_stride`, `join_chw`, `use_cache` |
+| `PoseModalityProcessor` | `.pose` files | `reduce_holistic_poses`, `skip_frames_stride`, `signal_start_end_unit` |
+| `VideoModalityProcessor` | Video files | `skip_frames_stride`, `join_chw`, `use_cache`, `signal_start_end_unit` |
 | `ImageModalityProcessor` | Image files / text-rendered images | `font_path`, `width`, `height`, `normalize_image`, `mean`, `std` |
 | `FeaturesModalityProcessor` | `.npy` / `.pt` feature files | `skip_frames_stride`, `temporal_dimension_position`, `use_cache` |
 | `SignwritingModalityProcessor` | FSW SignWriting strings | `custom_preprocessor_path`, `width`, `height`, `channels` |

--- a/multimodalhugs/data/datasets/pose2text.py
+++ b/multimodalhugs/data/datasets/pose2text.py
@@ -25,6 +25,7 @@ from multimodalhugs.data import (
 )
 from multimodalhugs.utils.utils import get_num_proc
 from multimodalhugs.utils.registry import register_dataset
+from multimodalhugs.processors.utils import SignalUnit
 
 from functools import lru_cache
 
@@ -52,9 +53,9 @@ class Pose2TextDataConfig(MultimodalDataConfig):
         default=None,
         metadata={"help": "Pose related samples shorter than this value will be filtered"}
     )
-    signal_start_end_unit: str = field(
-        default="milliseconds",
-        metadata={"help": "Unit for signal_start/signal_end: 'milliseconds' or 'frames'"}
+    signal_start_end_unit: Union[str, SignalUnit] = field(
+        default=SignalUnit.MILLISECONDS,
+        metadata={"help": "Unit for signal_start/signal_end. Use SignalUnit.MILLISECONDS or SignalUnit.FRAMES."}
     )
     def __init__(self, cfg=None, **kwargs):
         """
@@ -71,7 +72,7 @@ class Pose2TextDataConfig(MultimodalDataConfig):
         # Assign new arguments from config if available
         self.max_frames = valid_config.get("max_frames", self.max_frames)
         self.min_frames = valid_config.get("min_frames", self.min_frames)
-        self.signal_start_end_unit = valid_config.get("signal_start_end_unit", self.signal_start_end_unit)
+        self.signal_start_end_unit = SignalUnit(valid_config.get("signal_start_end_unit", self.signal_start_end_unit))
 
         # Store any remaining kwargs (not expected by dataclass)
         self._extra_args = extra_args
@@ -232,7 +233,7 @@ class Pose2TextDataset(datasets.GeneratorBasedBuilder):
             signal_end = sample['signal_end'] or 0
 
             with open(sample['signal'], "rb") as f:
-                if signal_start_end_unit == "frames":
+                if signal_start_end_unit == SignalUnit.FRAMES:
                     start_f = int(signal_start) if signal_start else None
                     end_f = int(signal_end) if signal_end else None
                     pose = Pose.read(f, start_frame=start_f, end_frame=end_f)

--- a/multimodalhugs/data/datasets/pose2text.py
+++ b/multimodalhugs/data/datasets/pose2text.py
@@ -1,5 +1,4 @@
 import os
-import math
 import torch
 import datasets
 
@@ -46,19 +45,23 @@ class Pose2TextDataConfig(MultimodalDataConfig):
     """
     name: str = "Pose2TextDataConfig"
     max_frames: Optional[int] = field(
-        default=None, 
+        default=None,
         metadata={"help": "Pose related samples larger than this value will be filtered"}
     )
     min_frames: Optional[int] = field(
-        default=None, 
+        default=None,
         metadata={"help": "Pose related samples shorter than this value will be filtered"}
+    )
+    signal_start_end_unit: str = field(
+        default="milliseconds",
+        metadata={"help": "Unit for signal_start/signal_end: 'milliseconds' or 'frames'"}
     )
     def __init__(self, cfg=None, **kwargs):
         """
         **Initialize the Pose2TextDataConfig.**
 
-        This constructor assigns configuration parameters based on the provided 
-        `cfg` object, if available. If no configuration is given, it falls back 
+        This constructor assigns configuration parameters based on the provided
+        `cfg` object, if available. If no configuration is given, it falls back
         to default values.
         """
         data_cfg = gather_appropriate_data_cfg(cfg)
@@ -68,6 +71,7 @@ class Pose2TextDataConfig(MultimodalDataConfig):
         # Assign new arguments from config if available
         self.max_frames = valid_config.get("max_frames", self.max_frames)
         self.min_frames = valid_config.get("min_frames", self.min_frames)
+        self.signal_start_end_unit = valid_config.get("signal_start_end_unit", self.signal_start_end_unit)
 
         # Store any remaining kwargs (not expected by dataclass)
         self._extra_args = extra_args
@@ -118,6 +122,7 @@ class Pose2TextDataset(datasets.GeneratorBasedBuilder):
         self.config = config
         self.max_frames = config.max_frames
         self.min_frames = config.min_frames
+        self.signal_start_end_unit = config.signal_start_end_unit
 
     def _info(self):
         """
@@ -211,6 +216,8 @@ class Pose2TextDataset(datasets.GeneratorBasedBuilder):
         # passed from _split_generators. load_dataset requires split="train" to avoid returning a dict of splits.
         dataset = load_dataset('csv', data_files=str(metafile_path), split='train', delimiter="\t", num_proc=get_num_proc()) 
 
+        signal_start_end_unit = self.signal_start_end_unit
+
         def mapping_function(sample):
             """
             **Process each sample by reading the pose buffer and calculating duration.**
@@ -221,12 +228,22 @@ class Pose2TextDataset(datasets.GeneratorBasedBuilder):
             **Returns:**
             - `dict`: The updated sample with the pose data duration.
             """
-            pose = read_pose(sample['signal'])
-            sample['DURATION'] = pose.body.duration_in_frames(
-                start_time=sample['signal_start'] or None, 
-                end_time=sample['signal_end'] or None
-            )
+            signal_start = sample['signal_start'] or 0
+            signal_end = sample['signal_end'] or 0
 
+            with open(sample['signal'], "rb") as f:
+                if signal_start_end_unit == "frames":
+                    start_f = int(signal_start) if signal_start else None
+                    end_f = int(signal_end) if signal_end else None
+                    pose = Pose.read(f, start_frame=start_f, end_frame=end_f)
+                else:
+                    pose = Pose.read(
+                        f,
+                        start_time=signal_start or None,
+                        end_time=signal_end or None,
+                    )
+
+            sample['DURATION'] = pose.body.duration_in_frames()
             return sample
 
         # Filter out samples where the file path does not exist

--- a/multimodalhugs/data/datasets/pose2text.py
+++ b/multimodalhugs/data/datasets/pose2text.py
@@ -53,7 +53,7 @@ class Pose2TextDataConfig(MultimodalDataConfig):
         default=None,
         metadata={"help": "Pose related samples shorter than this value will be filtered"}
     )
-    signal_start_end_unit: Union[str, SignalUnit] = field(
+    signal_start_end_unit: SignalUnit = field(
         default=SignalUnit.MILLISECONDS,
         metadata={"help": "Unit for signal_start/signal_end. Use SignalUnit.MILLISECONDS or SignalUnit.FRAMES."}
     )

--- a/multimodalhugs/data/datasets/video2text.py
+++ b/multimodalhugs/data/datasets/video2text.py
@@ -52,7 +52,7 @@ class Video2TextDataConfig(MultimodalDataConfig):
         default=None,
         metadata={"help": "Filter out videos shorter than this value (in frames)"}
     )
-    signal_start_end_unit: Union[str, SignalUnit] = field(
+    signal_start_end_unit: SignalUnit = field(
         default=SignalUnit.MILLISECONDS,
         metadata={"help": "Unit for signal_start/signal_end. Use SignalUnit.MILLISECONDS or SignalUnit.FRAMES."}
     )

--- a/multimodalhugs/data/datasets/video2text.py
+++ b/multimodalhugs/data/datasets/video2text.py
@@ -48,8 +48,12 @@ class Video2TextDataConfig(MultimodalDataConfig):
         metadata={"help": "Filter out videos longer than this (in frames)."}
     )
     min_frames: Optional[int] = field(
-        default=None, 
+        default=None,
         metadata={"help": "Filter out videos shorter than this value (in frames)"}
+    )
+    signal_start_end_unit: str = field(
+        default="milliseconds",
+        metadata={"help": "Unit for signal_start/signal_end: 'milliseconds' or 'frames'"}
     )
     def __init__(self, cfg=None, **kwargs):
         data_cfg = gather_appropriate_data_cfg(cfg)
@@ -58,6 +62,7 @@ class Video2TextDataConfig(MultimodalDataConfig):
         # pull from OmegaConf yaml (or leave defaults)
         self.max_frames = valid_config.get("max_frames", self.max_frames)
         self.min_frames = valid_config.get("min_frames", self.min_frames)
+        self.signal_start_end_unit = valid_config.get("signal_start_end_unit", self.signal_start_end_unit)
 
 @register_dataset("video2text")
 class Video2TextDataset(datasets.GeneratorBasedBuilder):
@@ -93,6 +98,7 @@ class Video2TextDataset(datasets.GeneratorBasedBuilder):
         self.config = config
         self.max_frames = config.max_frames
         self.min_frames = config.min_frames
+        self.signal_start_end_unit = config.signal_start_end_unit
 
     def _info(self):
         features = {
@@ -156,20 +162,39 @@ class Video2TextDataset(datasets.GeneratorBasedBuilder):
         # Filter missing files
         dataset = dataset.filter(lambda ex: file_exists_filter("signal", ex), num_proc=get_num_proc())
 
+        signal_start_end_unit = self.signal_start_end_unit
+
         def mapping_function(sample: Dict[str, Any]) -> Dict[str, Any]:
             video_path = sample["signal"]
-            # Convert millisecond timestamps to seconds
-            start_ms = sample.get("signal_start", 0) or 0
-            end_ms   = sample.get("signal_end",   0) or 0
-            start_sec = start_ms / 1000.0
-            end_sec   = end_ms   / 1000.0 if end_ms > 0 else None
+            signal_start = sample.get("signal_start", 0) or 0
+            signal_end   = sample.get("signal_end",   0) or 0
+            full_signal  = signal_start == 0 and signal_end == 0
 
-            # Try to open and seek; skip if no video stream or any error
+            # Open the container to validate the video stream.
             container = av.open(str(video_path))
             if not container.streams.video:
+                container.close()
                 sample["_invalid"] = True
                 sample["DURATION"] = 0
                 return sample
+
+            if signal_start_end_unit == "frames" and not full_signal:
+                # Frame indices: duration is trivially signal_end - signal_start.
+                # No frame decoding needed.
+                container.close()
+                sample["DURATION"] = int(signal_end) - int(signal_start)
+                sample["_invalid"] = False
+                return sample
+
+            # For the ms unit (any bounds) or frames unit with full-file load:
+            # count frames by decoding through av, seeking by time.
+            if signal_start_end_unit == "milliseconds":
+                start_sec = signal_start / 1000.0
+                end_sec   = signal_end   / 1000.0 if signal_end > 0 else None
+            else:
+                # frames unit, full file (0/0)
+                start_sec = 0.0
+                end_sec   = None
 
             stream = container.streams.video[0]
             start_pts = int(start_sec / float(stream.time_base))
@@ -185,10 +210,10 @@ class Video2TextDataset(datasets.GeneratorBasedBuilder):
                 count_new += 1
             container.close()
 
-            # If within ±2 frames of the threshold, fallback to old method
+            # For the ms unit, if within ±2 frames of the threshold fall back
+            # to torchvision for an exact count.
             maxf = self.max_frames
-            if maxf is not None and abs(count_new - maxf) <= 2:
-                # --- Fallback (torchvision.read_video) ---
+            if signal_start_end_unit == "milliseconds" and maxf is not None and abs(count_new - maxf) <= 2:
                 frames, _, _ = read_video(
                     str(video_path),
                     start_pts=start_sec,

--- a/multimodalhugs/data/datasets/video2text.py
+++ b/multimodalhugs/data/datasets/video2text.py
@@ -32,6 +32,7 @@ from multimodalhugs.data import (
 
 from multimodalhugs.utils.utils import get_num_proc
 from multimodalhugs.utils.registry import register_dataset
+from multimodalhugs.processors.utils import SignalUnit
 
 @dataclass
 class Video2TextDataConfig(MultimodalDataConfig):
@@ -51,9 +52,9 @@ class Video2TextDataConfig(MultimodalDataConfig):
         default=None,
         metadata={"help": "Filter out videos shorter than this value (in frames)"}
     )
-    signal_start_end_unit: str = field(
-        default="milliseconds",
-        metadata={"help": "Unit for signal_start/signal_end: 'milliseconds' or 'frames'"}
+    signal_start_end_unit: Union[str, SignalUnit] = field(
+        default=SignalUnit.MILLISECONDS,
+        metadata={"help": "Unit for signal_start/signal_end. Use SignalUnit.MILLISECONDS or SignalUnit.FRAMES."}
     )
     def __init__(self, cfg=None, **kwargs):
         data_cfg = gather_appropriate_data_cfg(cfg)
@@ -62,7 +63,7 @@ class Video2TextDataConfig(MultimodalDataConfig):
         # pull from OmegaConf yaml (or leave defaults)
         self.max_frames = valid_config.get("max_frames", self.max_frames)
         self.min_frames = valid_config.get("min_frames", self.min_frames)
-        self.signal_start_end_unit = valid_config.get("signal_start_end_unit", self.signal_start_end_unit)
+        self.signal_start_end_unit = SignalUnit(valid_config.get("signal_start_end_unit", self.signal_start_end_unit))
 
 @register_dataset("video2text")
 class Video2TextDataset(datasets.GeneratorBasedBuilder):
@@ -178,7 +179,7 @@ class Video2TextDataset(datasets.GeneratorBasedBuilder):
                 sample["DURATION"] = 0
                 return sample
 
-            if signal_start_end_unit == "frames" and not full_signal:
+            if signal_start_end_unit == SignalUnit.FRAMES and not full_signal:
                 # Frame indices: duration is trivially signal_end - signal_start.
                 # No frame decoding needed.
                 container.close()
@@ -188,7 +189,7 @@ class Video2TextDataset(datasets.GeneratorBasedBuilder):
 
             # For the ms unit (any bounds) or frames unit with full-file load:
             # count frames by decoding through av, seeking by time.
-            if signal_start_end_unit == "milliseconds":
+            if signal_start_end_unit == SignalUnit.MILLISECONDS:
                 start_sec = signal_start / 1000.0
                 end_sec   = signal_end   / 1000.0 if signal_end > 0 else None
             else:
@@ -213,7 +214,7 @@ class Video2TextDataset(datasets.GeneratorBasedBuilder):
             # For the ms unit, if within ±2 frames of the threshold fall back
             # to torchvision for an exact count.
             maxf = self.max_frames
-            if signal_start_end_unit == "milliseconds" and maxf is not None and abs(count_new - maxf) <= 2:
+            if signal_start_end_unit == SignalUnit.MILLISECONDS and maxf is not None and abs(count_new - maxf) <= 2:
                 frames, _, _ = read_video(
                     str(video_path),
                     start_pts=start_sec,

--- a/multimodalhugs/processors/legacy/pose2text_preprocessor.py
+++ b/multimodalhugs/processors/legacy/pose2text_preprocessor.py
@@ -24,10 +24,12 @@ class Pose2TextTranslationProcessor(MultimodalMetaProcessor):
         tokenizer: Optional[Any] = None,
         reduce_holistic_poses: bool = True,
         skip_frames_stride: Optional[int] = None,
+        signal_start_end_unit: str = "milliseconds",
         **kwargs,
     ):
         self.reduce_holistic_poses = reduce_holistic_poses
         self.skip_frames_stride = skip_frames_stride
+        self.signal_start_end_unit = signal_start_end_unit
         # Pass-through for from_pretrained, which calls cls(slots=..., tokenizer=...)
         if "slots" in kwargs:
             super().__init__(tokenizer=tokenizer, **kwargs)
@@ -38,6 +40,7 @@ class Pose2TextTranslationProcessor(MultimodalMetaProcessor):
                     processor=PoseModalityProcessor(
                         reduce_holistic_poses=reduce_holistic_poses,
                         skip_frames_stride=skip_frames_stride,
+                        signal_start_end_unit=signal_start_end_unit,
                     ),
                     output_data_key="input_frames",
                     output_mask_key="attention_mask",

--- a/multimodalhugs/processors/legacy/pose2text_preprocessor.py
+++ b/multimodalhugs/processors/legacy/pose2text_preprocessor.py
@@ -1,9 +1,10 @@
 import logging
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from multimodalhugs.processors.meta_processor import MultimodalMetaProcessor, ProcessorSlot
 from multimodalhugs.processors.pose_modality_processor import PoseModalityProcessor
 from multimodalhugs.processors.text_modality_processor import TextModalityProcessor, TextRole
+from multimodalhugs.processors.utils import SignalUnit
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +25,7 @@ class Pose2TextTranslationProcessor(MultimodalMetaProcessor):
         tokenizer: Optional[Any] = None,
         reduce_holistic_poses: bool = True,
         skip_frames_stride: Optional[int] = None,
-        signal_start_end_unit: str = "milliseconds",
+        signal_start_end_unit: Union[str, SignalUnit] = SignalUnit.MILLISECONDS,
         **kwargs,
     ):
         self.reduce_holistic_poses = reduce_holistic_poses

--- a/multimodalhugs/processors/legacy/pose2text_preprocessor.py
+++ b/multimodalhugs/processors/legacy/pose2text_preprocessor.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 from multimodalhugs.processors.meta_processor import MultimodalMetaProcessor, ProcessorSlot
 from multimodalhugs.processors.pose_modality_processor import PoseModalityProcessor
@@ -25,7 +25,7 @@ class Pose2TextTranslationProcessor(MultimodalMetaProcessor):
         tokenizer: Optional[Any] = None,
         reduce_holistic_poses: bool = True,
         skip_frames_stride: Optional[int] = None,
-        signal_start_end_unit: Union[str, SignalUnit] = SignalUnit.MILLISECONDS,
+        signal_start_end_unit: SignalUnit = SignalUnit.MILLISECONDS,
         **kwargs,
     ):
         self.reduce_holistic_poses = reduce_holistic_poses

--- a/multimodalhugs/processors/legacy/video2text_preprocessor.py
+++ b/multimodalhugs/processors/legacy/video2text_preprocessor.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 from multimodalhugs.processors.meta_processor import MultimodalMetaProcessor, ProcessorSlot
 from multimodalhugs.processors.video_modality_processor import VideoModalityProcessor
@@ -27,7 +27,7 @@ class Video2TextTranslationProcessor(MultimodalMetaProcessor):
         skip_frames_stride: Optional[int] = None,
         join_chw: bool = False,
         use_cache: bool = True,
-        signal_start_end_unit: Union[str, SignalUnit] = SignalUnit.MILLISECONDS,
+        signal_start_end_unit: SignalUnit = SignalUnit.MILLISECONDS,
         **kwargs,
     ):
         self.custom_preprocessor_path = custom_preprocessor_path

--- a/multimodalhugs/processors/legacy/video2text_preprocessor.py
+++ b/multimodalhugs/processors/legacy/video2text_preprocessor.py
@@ -1,9 +1,10 @@
 import logging
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from multimodalhugs.processors.meta_processor import MultimodalMetaProcessor, ProcessorSlot
 from multimodalhugs.processors.video_modality_processor import VideoModalityProcessor
 from multimodalhugs.processors.text_modality_processor import TextModalityProcessor, TextRole
+from multimodalhugs.processors.utils import SignalUnit
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +27,7 @@ class Video2TextTranslationProcessor(MultimodalMetaProcessor):
         skip_frames_stride: Optional[int] = None,
         join_chw: bool = False,
         use_cache: bool = True,
-        signal_start_end_unit: str = "milliseconds",
+        signal_start_end_unit: Union[str, SignalUnit] = SignalUnit.MILLISECONDS,
         **kwargs,
     ):
         self.custom_preprocessor_path = custom_preprocessor_path

--- a/multimodalhugs/processors/legacy/video2text_preprocessor.py
+++ b/multimodalhugs/processors/legacy/video2text_preprocessor.py
@@ -26,12 +26,14 @@ class Video2TextTranslationProcessor(MultimodalMetaProcessor):
         skip_frames_stride: Optional[int] = None,
         join_chw: bool = False,
         use_cache: bool = True,
+        signal_start_end_unit: str = "milliseconds",
         **kwargs,
     ):
         self.custom_preprocessor_path = custom_preprocessor_path
         self.skip_frames_stride = skip_frames_stride
         self.join_chw = join_chw
         self.use_cache = use_cache
+        self.signal_start_end_unit = signal_start_end_unit
         if "slots" in kwargs:
             super().__init__(tokenizer=tokenizer, **kwargs)
             return
@@ -43,6 +45,7 @@ class Video2TextTranslationProcessor(MultimodalMetaProcessor):
                         skip_frames_stride=skip_frames_stride,
                         join_chw=join_chw,
                         use_cache=use_cache,
+                        signal_start_end_unit=signal_start_end_unit,
                     ),
                     output_data_key="input_frames",
                     output_mask_key="attention_mask",

--- a/multimodalhugs/processors/pose_modality_processor.py
+++ b/multimodalhugs/processors/pose_modality_processor.py
@@ -29,6 +29,7 @@ class PoseModalityProcessor(ModalityProcessor):
         self,
         reduce_holistic_poses: bool = True,
         skip_frames_stride: Optional[int] = None,
+        signal_start_end_unit: str = "milliseconds",
     ):
         """
         Args:
@@ -38,14 +39,28 @@ class PoseModalityProcessor(ModalityProcessor):
             skip_frames_stride: If set, keeps only every N-th frame along the
                 temporal axis after loading (e.g. 2 → halve frame rate).
                 None disables downsampling. Default: None.
+            signal_start_end_unit: Unit for ``signal_start`` / ``signal_end``
+                values in the dataset.  Either ``"milliseconds"`` (default,
+                current behaviour — values are passed to ``Pose.read`` as
+                ``start_time``/``end_time``) or ``"frames"`` (values are used
+                as frame indices to slice the loaded tensor directly).
+                When ``signal_start=0`` and ``signal_end=0`` the full file is
+                always loaded regardless of this setting.
         """
         if not _POSE_FORMAT_AVAILABLE:
             raise ImportError(
                 "PoseModalityProcessor requires 'pose-format'. "
                 'Install it with: pip install pose-format  or  pip install "multimodalhugs[pose]"'
             )
+        _valid_units = {"milliseconds", "frames"}
+        if signal_start_end_unit not in _valid_units:
+            raise ValueError(
+                f"Invalid signal_start_end_unit '{signal_start_end_unit}'. "
+                f"Must be one of: {sorted(_valid_units)}."
+            )
         self.reduce_holistic_poses = reduce_holistic_poses
         self.skip_frames_stride = skip_frames_stride
+        self.signal_start_end_unit = signal_start_end_unit
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -66,26 +81,43 @@ class PoseModalityProcessor(ModalityProcessor):
 
         Args:
             pose_file: Path to a binary .pose file.
-            signal_start: Clip start time in milliseconds. 0 means start of file.
-            signal_end: Clip end time in milliseconds. 0 means end of file.
+            signal_start: Clip start value. When ``signal_start_end_unit`` is
+                ``"milliseconds"`` this is a time in ms passed directly to
+                ``Pose.read``; when ``"frames"`` it is a frame index used to
+                slice the output tensor. 0 means start of file in both units.
+            signal_end: Clip end value. Same unit logic as ``signal_start``.
+                0 means end of file in both units.
 
         Returns:
             Float tensor of shape [T, D] where T is the number of frames
             (after optional downsampling) and D is the flattened landmark
             feature dimension.
         """
-        with open(pose_file, "rb") as f:
-            pose = Pose.read(
-                f,
-                start_time=signal_start or None,
-                end_time=signal_end or None,
-            )
+        if self.signal_start_end_unit == "milliseconds":
+            with open(pose_file, "rb") as f:
+                pose = Pose.read(
+                    f,
+                    start_time=signal_start or None,
+                    end_time=signal_end or None,
+                )
+        else:
+            # Load the full file; frame-based slicing is applied after
+            # preprocessing so that normalization sees the complete pose.
+            with open(pose_file, "rb") as f:
+                pose = Pose.read(f)
+
         pose_hide_legs(pose)
         if self.reduce_holistic_poses:
             pose = reduce_holistic(pose)
         pose = pose.normalize()
         tensor = pose.torch().body.data.zero_filled()
         tensor = tensor.contiguous().view(tensor.size(0), -1)
+
+        if self.signal_start_end_unit == "frames":
+            start_frame = signal_start if signal_start else None
+            end_frame = signal_end if signal_end else None
+            tensor = tensor[start_frame:end_frame]
+
         if self.skip_frames_stride is not None:
             tensor = frame_skipping(x=tensor, t_dim=0, stride=self.skip_frames_stride)
         return tensor
@@ -108,8 +140,10 @@ class PoseModalityProcessor(ModalityProcessor):
                 - torch.Tensor — returned unchanged (already preprocessed).
                 - dict — mapping with keys:
                     ``"signal"`` (str/Path, required): path to the .pose file.
-                    ``"signal_start"`` (int, optional): clip start in ms. Default 0.
-                    ``"signal_end"`` (int, optional): clip end in ms. Default 0.
+                    ``"signal_start"`` (int, optional): clip start in the unit
+                    given by ``signal_start_end_unit``. Default 0 (start of file).
+                    ``"signal_end"`` (int, optional): clip end in the unit given
+                    by ``signal_start_end_unit``. Default 0 (end of file).
 
         Returns:
             Float tensor of shape [T, D].

--- a/multimodalhugs/processors/pose_modality_processor.py
+++ b/multimodalhugs/processors/pose_modality_processor.py
@@ -29,7 +29,7 @@ class PoseModalityProcessor(ModalityProcessor):
         self,
         reduce_holistic_poses: bool = True,
         skip_frames_stride: Optional[int] = None,
-        signal_start_end_unit: Union[str, SignalUnit] = SignalUnit.MILLISECONDS,
+        signal_start_end_unit: SignalUnit = SignalUnit.MILLISECONDS,
     ):
         """
         Args:
@@ -47,8 +47,6 @@ class PoseModalityProcessor(ModalityProcessor):
                 ``start_frame``/``end_frame``).
                 When ``signal_start=0`` and ``signal_end=0`` the full file is
                 always loaded regardless of this setting.
-                Plain strings ``"milliseconds"`` and ``"frames"`` are also
-                accepted for backward compatibility.
         """
         if not _POSE_FORMAT_AVAILABLE:
             raise ImportError(

--- a/multimodalhugs/processors/pose_modality_processor.py
+++ b/multimodalhugs/processors/pose_modality_processor.py
@@ -12,7 +12,7 @@ except ImportError:
 
 from multimodalhugs.data import pad_and_create_mask
 from multimodalhugs.processors.modality_processor import ModalityProcessor, ProcessBatchOutput
-from multimodalhugs.processors.utils import frame_skipping
+from multimodalhugs.processors.utils import frame_skipping, SignalUnit
 
 
 class PoseModalityProcessor(ModalityProcessor):
@@ -29,7 +29,7 @@ class PoseModalityProcessor(ModalityProcessor):
         self,
         reduce_holistic_poses: bool = True,
         skip_frames_stride: Optional[int] = None,
-        signal_start_end_unit: str = "milliseconds",
+        signal_start_end_unit: Union[str, SignalUnit] = SignalUnit.MILLISECONDS,
     ):
         """
         Args:
@@ -40,23 +40,27 @@ class PoseModalityProcessor(ModalityProcessor):
                 temporal axis after loading (e.g. 2 → halve frame rate).
                 None disables downsampling. Default: None.
             signal_start_end_unit: Unit for ``signal_start`` / ``signal_end``
-                values in the dataset.  Either ``"milliseconds"`` (default,
-                current behaviour — values are passed to ``Pose.read`` as
-                ``start_time``/``end_time``) or ``"frames"`` (values are used
-                as frame indices to slice the loaded tensor directly).
+                values in the dataset.  Either ``SignalUnit.MILLISECONDS``
+                (default, current behaviour — values are passed to ``Pose.read``
+                as ``start_time``/``end_time``) or ``SignalUnit.FRAMES``
+                (values are used as frame indices passed to ``Pose.read`` as
+                ``start_frame``/``end_frame``).
                 When ``signal_start=0`` and ``signal_end=0`` the full file is
                 always loaded regardless of this setting.
+                Plain strings ``"milliseconds"`` and ``"frames"`` are also
+                accepted for backward compatibility.
         """
         if not _POSE_FORMAT_AVAILABLE:
             raise ImportError(
                 "PoseModalityProcessor requires 'pose-format'. "
                 'Install it with: pip install pose-format  or  pip install "multimodalhugs[pose]"'
             )
-        _valid_units = {"milliseconds", "frames"}
-        if signal_start_end_unit not in _valid_units:
+        try:
+            signal_start_end_unit = SignalUnit(signal_start_end_unit)
+        except ValueError:
             raise ValueError(
                 f"Invalid signal_start_end_unit '{signal_start_end_unit}'. "
-                f"Must be one of: {sorted(_valid_units)}."
+                f"Must be one of: {[u.value for u in SignalUnit]}."
             )
         self.reduce_holistic_poses = reduce_holistic_poses
         self.skip_frames_stride = skip_frames_stride

--- a/multimodalhugs/processors/pose_modality_processor.py
+++ b/multimodalhugs/processors/pose_modality_processor.py
@@ -114,8 +114,11 @@ class PoseModalityProcessor(ModalityProcessor):
         tensor = tensor.contiguous().view(tensor.size(0), -1)
 
         if self.signal_start_end_unit == "frames":
-            start_frame = signal_start if signal_start else None
-            end_frame = signal_end if signal_end else None
+            # Note: normalization above sees the full sequence, which differs from
+            # the milliseconds path where Pose.read clips before normalization.
+            # This is intentional: frame-based slicing avoids re-reading the file.
+            start_frame = int(signal_start) if signal_start else None
+            end_frame = int(signal_end) if signal_end else None
             tensor = tensor[start_frame:end_frame]
 
         if self.skip_frames_stride is not None:

--- a/multimodalhugs/processors/pose_modality_processor.py
+++ b/multimodalhugs/processors/pose_modality_processor.py
@@ -101,10 +101,15 @@ class PoseModalityProcessor(ModalityProcessor):
                     end_time=signal_end or None,
                 )
         else:
-            # Load the full file; frame-based slicing is applied after
-            # preprocessing so that normalization sees the complete pose.
+            # Pose.read natively accepts start_frame/end_frame and uses a
+            # seek-capable reader, so normalization sees only the requested
+            # window — consistent with the milliseconds path.
+            # Note: start_frame/end_frame and start_time/end_time cannot be
+            # mixed; Pose.read raises ValueError if both are set.
+            start_f = int(signal_start) if signal_start else None
+            end_f = int(signal_end) if signal_end else None
             with open(pose_file, "rb") as f:
-                pose = Pose.read(f)
+                pose = Pose.read(f, start_frame=start_f, end_frame=end_f)
 
         pose_hide_legs(pose)
         if self.reduce_holistic_poses:
@@ -112,14 +117,6 @@ class PoseModalityProcessor(ModalityProcessor):
         pose = pose.normalize()
         tensor = pose.torch().body.data.zero_filled()
         tensor = tensor.contiguous().view(tensor.size(0), -1)
-
-        if self.signal_start_end_unit == "frames":
-            # Note: normalization above sees the full sequence, which differs from
-            # the milliseconds path where Pose.read clips before normalization.
-            # This is intentional: frame-based slicing avoids re-reading the file.
-            start_frame = int(signal_start) if signal_start else None
-            end_frame = int(signal_end) if signal_end else None
-            tensor = tensor[start_frame:end_frame]
 
         if self.skip_frames_stride is not None:
             tensor = frame_skipping(x=tensor, t_dim=0, stride=self.skip_frames_stride)

--- a/multimodalhugs/processors/utils.py
+++ b/multimodalhugs/processors/utils.py
@@ -1,7 +1,26 @@
 import os
+from enum import Enum
 
 import psutil
 import torch
+
+try:
+    from enum import StrEnum  # Python 3.11+
+except ImportError:
+    class StrEnum(str, Enum):  # type: ignore[no-redef]
+        pass
+
+
+class SignalUnit(StrEnum):
+    """
+    Valid units for the ``signal_start`` / ``signal_end`` dataset columns.
+
+    Attributes:
+        MILLISECONDS: Values are timestamps in milliseconds (default).
+        FRAMES: Values are frame indices (0-based, exclusive end).
+    """
+    MILLISECONDS = "milliseconds"
+    FRAMES = "frames"
 
 
 def get_dynamic_cache_size(avg_item_size_bytes: float) -> int:

--- a/multimodalhugs/processors/video_modality_processor.py
+++ b/multimodalhugs/processors/video_modality_processor.py
@@ -45,6 +45,7 @@ class VideoModalityProcessor(ModalityProcessor):
         join_chw: bool = False,
         use_cache: bool = False,
         io_max_retries: int = 3,
+        signal_start_end_unit: str = "milliseconds",
     ):
         """
         Args:
@@ -67,6 +68,15 @@ class VideoModalityProcessor(ModalityProcessor):
                 file fails with an I/O error. Retries use exponential backoff
                 (1 s, 2 s, 4 s, …) to tolerate transient NFS slowness on
                 shared clusters. Default: 3.
+            signal_start_end_unit: Unit for ``signal_start`` / ``signal_end``
+                values in the dataset.  Either ``"milliseconds"`` (default,
+                current behaviour — for the OpenCV path values are used with
+                ``CAP_PROP_POS_MSEC``; for the torchvision path values are
+                converted to seconds) or ``"frames"`` (values are used as
+                frame indices: ``CAP_PROP_POS_FRAMES`` for the OpenCV path,
+                direct tensor slicing for the torchvision path).
+                When ``signal_start=0`` and ``signal_end=0`` the full file is
+                always loaded regardless of this setting.
         """
         if custom_preprocessor_path is not None and not _CV2_AVAILABLE:
             raise ImportError(
@@ -78,11 +88,18 @@ class VideoModalityProcessor(ModalityProcessor):
                 "VideoModalityProcessor requires 'torchvision'. "
                 'Install it with: pip install torchvision  or  pip install "multimodalhugs[video]"'
             )
+        _valid_units = {"milliseconds", "frames"}
+        if signal_start_end_unit not in _valid_units:
+            raise ValueError(
+                f"Invalid signal_start_end_unit '{signal_start_end_unit}'. "
+                f"Must be one of: {sorted(_valid_units)}."
+            )
         self.custom_preprocessor_path = custom_preprocessor_path
         self.skip_frames_stride = skip_frames_stride
         self.join_chw = join_chw
         self.use_cache = use_cache
         self.io_max_retries = io_max_retries
+        self.signal_start_end_unit = signal_start_end_unit
         self.custom_preprocessor = (
             AutoProcessor.from_pretrained(custom_preprocessor_path)
             if custom_preprocessor_path is not None
@@ -115,9 +132,11 @@ class VideoModalityProcessor(ModalityProcessor):
         Args:
             video_path: Path to a video file (any format supported by OpenCV
                 or torchvision).
-            signal_start: Clip start time in milliseconds. 0.0 means start of
-                file.
-            signal_end: Clip end time in milliseconds. 0.0 means end of file.
+            signal_start: Clip start value. When ``signal_start_end_unit`` is
+                ``"milliseconds"`` this is a time in ms; when ``"frames"`` it
+                is a frame index. 0.0 means start of file in both units.
+            signal_end: Clip end value. Same unit logic as ``signal_start``.
+                0.0 means end of file in both units.
 
         Returns:
             Float tensor of shape [T, C, H, W] (or [T, C*H*W] when
@@ -139,31 +158,51 @@ class VideoModalityProcessor(ModalityProcessor):
 
                     full_signal = (signal_start == signal_end) or (signal_start is None) or (signal_end is None)
                     if not full_signal:
-                        cap.set(cv2.CAP_PROP_POS_MSEC, signal_start)
+                        if self.signal_start_end_unit == "frames":
+                            cap.set(cv2.CAP_PROP_POS_FRAMES, signal_start)
+                        else:
+                            cap.set(cv2.CAP_PROP_POS_MSEC, signal_start)
 
                     frames = []
                     while True:
                         ret, frame = cap.read()
                         if not ret:
                             break
-                        if not full_signal and cap.get(cv2.CAP_PROP_POS_MSEC) > signal_end:
-                            break
+                        if not full_signal:
+                            if self.signal_start_end_unit == "frames":
+                                if cap.get(cv2.CAP_PROP_POS_FRAMES) > signal_end:
+                                    break
+                            else:
+                                if cap.get(cv2.CAP_PROP_POS_MSEC) > signal_end:
+                                    break
                         frames.append(Image.fromarray(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)))
                     cap.release()
 
                     result = self.custom_preprocessor(images=frames, return_tensors="pt")["pixel_values"]
                     result = result.squeeze(0) if result.ndim == 5 else result
                 else:
-                    start_sec = (signal_start or 0) / 1000.0
-                    end_sec = (signal_end / 1000.0) if signal_end else None
-                    result, _, _ = read_video(
-                        str(video_path),
-                        start_pts=start_sec,
-                        end_pts=end_sec,
-                        pts_unit="sec",
-                        output_format="TCHW",
-                    )
-                    result = result.to(torch.float32)
+                    if self.signal_start_end_unit == "frames":
+                        # torchvision's read_video does not support frame-index
+                        # seeking, so we load the full video and slice by index.
+                        result, _, _ = read_video(
+                            str(video_path),
+                            pts_unit="sec",
+                            output_format="TCHW",
+                        )
+                        start_frame = int(signal_start) if signal_start else None
+                        end_frame = int(signal_end) if signal_end else None
+                        result = result[start_frame:end_frame].to(torch.float32)
+                    else:
+                        start_sec = (signal_start or 0) / 1000.0
+                        end_sec = (signal_end / 1000.0) if signal_end else None
+                        result, _, _ = read_video(
+                            str(video_path),
+                            start_pts=start_sec,
+                            end_pts=end_sec,
+                            pts_unit="sec",
+                            output_format="TCHW",
+                        )
+                        result = result.to(torch.float32)
 
                 if self.skip_frames_stride is not None:
                     result = frame_skipping(x=result, t_dim=0, stride=self.skip_frames_stride)
@@ -202,8 +241,10 @@ class VideoModalityProcessor(ModalityProcessor):
                 - np.ndarray — converted to a float tensor unchanged.
                 - dict — mapping with keys:
                     ``"signal"`` (str/Path, required): path to the video file.
-                    ``"signal_start"`` (float, optional): clip start in ms. Default 0.0.
-                    ``"signal_end"`` (float, optional): clip end in ms. Default 0.0.
+                    ``"signal_start"`` (float, optional): clip start in the unit
+                    given by ``signal_start_end_unit``. Default 0.0 (start of file).
+                    ``"signal_end"`` (float, optional): clip end in the unit given
+                    by ``signal_start_end_unit``. Default 0.0 (end of file).
 
         Returns:
             Float tensor of shape [T, C, H, W].

--- a/multimodalhugs/processors/video_modality_processor.py
+++ b/multimodalhugs/processors/video_modality_processor.py
@@ -184,6 +184,11 @@ class VideoModalityProcessor(ModalityProcessor):
                     if self.signal_start_end_unit == "frames":
                         # torchvision's read_video does not support frame-index
                         # seeking, so we load the full video and slice by index.
+                        # Note: when use_cache=True, each unique video_path is
+                        # cached as a full load; clip ranges are not part of the
+                        # cache key, so slicing is applied after the cache hit.
+                        # The cache size was calibrated for whole videos (~50 MB
+                        # each), not individual clips.
                         result, _, _ = read_video(
                             str(video_path),
                             pts_unit="sec",

--- a/multimodalhugs/processors/video_modality_processor.py
+++ b/multimodalhugs/processors/video_modality_processor.py
@@ -45,7 +45,7 @@ class VideoModalityProcessor(ModalityProcessor):
         join_chw: bool = False,
         use_cache: bool = False,
         io_max_retries: int = 3,
-        signal_start_end_unit: Union[str, SignalUnit] = SignalUnit.MILLISECONDS,
+        signal_start_end_unit: SignalUnit = SignalUnit.MILLISECONDS,
     ):
         """
         Args:
@@ -77,8 +77,6 @@ class VideoModalityProcessor(ModalityProcessor):
                 path, direct tensor slicing for the torchvision path).
                 When ``signal_start=0`` and ``signal_end=0`` the full file is
                 always loaded regardless of this setting.
-                Plain strings ``"milliseconds"`` and ``"frames"`` are also
-                accepted for backward compatibility.
         """
         if custom_preprocessor_path is not None and not _CV2_AVAILABLE:
             raise ImportError(

--- a/multimodalhugs/processors/video_modality_processor.py
+++ b/multimodalhugs/processors/video_modality_processor.py
@@ -184,11 +184,14 @@ class VideoModalityProcessor(ModalityProcessor):
                     if self.signal_start_end_unit == "frames":
                         # torchvision's read_video does not support frame-index
                         # seeking, so we load the full video and slice by index.
-                        # Note: when use_cache=True, each unique video_path is
-                        # cached as a full load; clip ranges are not part of the
-                        # cache key, so slicing is applied after the cache hit.
-                        # The cache size was calibrated for whole videos (~50 MB
-                        # each), not individual clips.
+                        # When use_cache=True the LRU cache key is
+                        # (video_path, signal_start, signal_end), so each
+                        # distinct clip range is a separate cache entry. On a
+                        # cache miss the full video is read from disk before
+                        # slicing; the sliced tensor is what gets stored.
+                        # The avg_item_size_bytes=50 MB estimate used to size
+                        # the cache was calibrated for full videos, not clips —
+                        # actual cached items may be much smaller.
                         result, _, _ = read_video(
                             str(video_path),
                             pts_unit="sec",

--- a/multimodalhugs/processors/video_modality_processor.py
+++ b/multimodalhugs/processors/video_modality_processor.py
@@ -23,7 +23,7 @@ except ImportError:
 
 from multimodalhugs.data import pad_and_create_mask
 from multimodalhugs.processors.modality_processor import ModalityProcessor, ProcessBatchOutput
-from multimodalhugs.processors.utils import frame_skipping, get_dynamic_cache_size
+from multimodalhugs.processors.utils import frame_skipping, get_dynamic_cache_size, SignalUnit
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +45,7 @@ class VideoModalityProcessor(ModalityProcessor):
         join_chw: bool = False,
         use_cache: bool = False,
         io_max_retries: int = 3,
-        signal_start_end_unit: str = "milliseconds",
+        signal_start_end_unit: Union[str, SignalUnit] = SignalUnit.MILLISECONDS,
     ):
         """
         Args:
@@ -69,14 +69,16 @@ class VideoModalityProcessor(ModalityProcessor):
                 (1 s, 2 s, 4 s, …) to tolerate transient NFS slowness on
                 shared clusters. Default: 3.
             signal_start_end_unit: Unit for ``signal_start`` / ``signal_end``
-                values in the dataset.  Either ``"milliseconds"`` (default,
-                current behaviour — for the OpenCV path values are used with
-                ``CAP_PROP_POS_MSEC``; for the torchvision path values are
-                converted to seconds) or ``"frames"`` (values are used as
-                frame indices: ``CAP_PROP_POS_FRAMES`` for the OpenCV path,
-                direct tensor slicing for the torchvision path).
+                values in the dataset.  Either ``SignalUnit.MILLISECONDS``
+                (default, current behaviour — for the OpenCV path values are
+                used with ``CAP_PROP_POS_MSEC``; for the torchvision path values
+                are converted to seconds) or ``SignalUnit.FRAMES`` (values are
+                used as frame indices: ``CAP_PROP_POS_FRAMES`` for the OpenCV
+                path, direct tensor slicing for the torchvision path).
                 When ``signal_start=0`` and ``signal_end=0`` the full file is
                 always loaded regardless of this setting.
+                Plain strings ``"milliseconds"`` and ``"frames"`` are also
+                accepted for backward compatibility.
         """
         if custom_preprocessor_path is not None and not _CV2_AVAILABLE:
             raise ImportError(
@@ -88,11 +90,12 @@ class VideoModalityProcessor(ModalityProcessor):
                 "VideoModalityProcessor requires 'torchvision'. "
                 'Install it with: pip install torchvision  or  pip install "multimodalhugs[video]"'
             )
-        _valid_units = {"milliseconds", "frames"}
-        if signal_start_end_unit not in _valid_units:
+        try:
+            signal_start_end_unit = SignalUnit(signal_start_end_unit)
+        except ValueError:
             raise ValueError(
                 f"Invalid signal_start_end_unit '{signal_start_end_unit}'. "
-                f"Must be one of: {sorted(_valid_units)}."
+                f"Must be one of: {[u.value for u in SignalUnit]}."
             )
         self.custom_preprocessor_path = custom_preprocessor_path
         self.skip_frames_stride = skip_frames_stride

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "multimodalhugs"
 description = "MultimodalHugs is an extension of Hugging Face that offers a generalized framework for training, evaluating, and using multimodal AI models with minimal code differences, ensuring seamless compatibility with Hugging Face pipelines."
-version = "0.5.1"
+version = "0.5.2"
 authors = [
     { name = "Gerard Sant", email = "gerard.santmuniesa@uzh.ch" },
     { name = "Zifan Jiang" },

--- a/tests/test_data/test_processor_pose2text.py
+++ b/tests/test_data/test_processor_pose2text.py
@@ -177,12 +177,12 @@ class TestPoseSignalStartEndUnit:
             reduce_holistic_poses=True,
             signal_start_end_unit="frames",
         )
-        # dummy_pose_file has 10 frames; request first 5
+        # dummy_pose_file is created with fake_pose(num_frames=10) in conftest.py
         tensor_full = proc_full.process_sample(dummy_pose_file)
         tensor_sliced = proc_sliced.process_sample(
-            {"signal": dummy_pose_file, "signal_start": 0, "signal_end": 5}
+            {"signal": dummy_pose_file, "signal_start": 3, "signal_end": 8}
         )
-        assert tensor_sliced.shape[0] == 5
+        assert tensor_sliced.shape[0] == 5  # frames [3, 8)
         assert tensor_full.shape[0] == 10
 
     def test_frames_unit_zero_zero_loads_full_file(self, dummy_pose_file):

--- a/tests/test_data/test_processor_pose2text.py
+++ b/tests/test_data/test_processor_pose2text.py
@@ -1,11 +1,13 @@
 """Tests for Pose2TextTranslationProcessor."""
 
+import pytest
 import torch
 from transformers.feature_extraction_utils import BatchFeature
 
 from multimodalhugs.processors.legacy.pose2text_preprocessor import (
     Pose2TextTranslationProcessor,
 )
+from multimodalhugs.processors.pose_modality_processor import PoseModalityProcessor
 
 
 def _modality_proc(processor):
@@ -143,3 +145,79 @@ class TestPoseProcessorCall:
                 assert val.shape[0] == batch_size, (
                     f"Key '{key}' has batch dim {val.shape[0]}, expected {batch_size}"
                 )
+
+
+class TestPoseSignalStartEndUnit:
+    """Tests for the signal_start_end_unit parameter on PoseModalityProcessor."""
+
+    def test_default_unit_is_milliseconds(self, dummy_pose_file):
+        proc = PoseModalityProcessor(reduce_holistic_poses=True)
+        assert proc.signal_start_end_unit == "milliseconds"
+
+    def test_frames_unit_accepted(self, dummy_pose_file):
+        proc = PoseModalityProcessor(
+            reduce_holistic_poses=True,
+            signal_start_end_unit="frames",
+        )
+        tensor = proc.process_sample(dummy_pose_file)
+        assert isinstance(tensor, torch.Tensor)
+        assert tensor.ndim == 2
+
+    def test_invalid_unit_raises(self):
+        with pytest.raises(ValueError, match="signal_start_end_unit"):
+            PoseModalityProcessor(signal_start_end_unit="seconds")
+
+    def test_frames_unit_slices_output(self, dummy_pose_file):
+        """Requesting frames 0..5 should yield fewer frames than the full file."""
+        proc_full = PoseModalityProcessor(
+            reduce_holistic_poses=True,
+            signal_start_end_unit="frames",
+        )
+        proc_sliced = PoseModalityProcessor(
+            reduce_holistic_poses=True,
+            signal_start_end_unit="frames",
+        )
+        # dummy_pose_file has 10 frames; request first 5
+        tensor_full = proc_full.process_sample(dummy_pose_file)
+        tensor_sliced = proc_sliced.process_sample(
+            {"signal": dummy_pose_file, "signal_start": 0, "signal_end": 5}
+        )
+        assert tensor_sliced.shape[0] == 5
+        assert tensor_full.shape[0] == 10
+
+    def test_frames_unit_zero_zero_loads_full_file(self, dummy_pose_file):
+        """signal_start=0, signal_end=0 with unit='frames' loads the full file."""
+        proc = PoseModalityProcessor(
+            reduce_holistic_poses=True,
+            signal_start_end_unit="frames",
+        )
+        tensor = proc.process_sample(
+            {"signal": dummy_pose_file, "signal_start": 0, "signal_end": 0}
+        )
+        assert tensor.shape[0] == 10  # all frames present
+
+    def test_milliseconds_and_frames_unit_same_full_load(self, dummy_pose_file):
+        """Both units with start=0, end=0 should yield the same frame count."""
+        proc_ms = PoseModalityProcessor(
+            reduce_holistic_poses=True,
+            signal_start_end_unit="milliseconds",
+        )
+        proc_fr = PoseModalityProcessor(
+            reduce_holistic_poses=True,
+            signal_start_end_unit="frames",
+        )
+        t_ms = proc_ms.process_sample(
+            {"signal": dummy_pose_file, "signal_start": 0, "signal_end": 0}
+        )
+        t_fr = proc_fr.process_sample(
+            {"signal": dummy_pose_file, "signal_start": 0, "signal_end": 0}
+        )
+        assert t_ms.shape[0] == t_fr.shape[0]
+
+    def test_legacy_wrapper_passes_unit_through(self, tokenizer, dummy_pose_file):
+        """Pose2TextTranslationProcessor should propagate signal_start_end_unit."""
+        proc = Pose2TextTranslationProcessor(
+            tokenizer=tokenizer,
+            signal_start_end_unit="frames",
+        )
+        assert _modality_proc(proc).signal_start_end_unit == "frames"

--- a/tests/test_data/test_processor_video2text.py
+++ b/tests/test_data/test_processor_video2text.py
@@ -9,6 +9,7 @@ from multimodalhugs.processors.legacy.video2text_preprocessor import (
     Video2TextTranslationProcessor,
 )
 from multimodalhugs.processors.video_modality_processor import VideoModalityProcessor
+from tests.test_data.conftest import CLIP_PROCESSOR_PATH
 
 
 def _modality_proc(processor):
@@ -180,3 +181,21 @@ class TestVideoSignalStartEndUnit:
             signal_start_end_unit="frames",
         )
         assert _modality_proc(proc).signal_start_end_unit == "frames"
+
+    def test_opencv_path_frames_unit_slices_output(self, dummy_video_file):
+        """OpenCV path: signal_start_end_unit='frames' should slice by frame index."""
+        proc_full = VideoModalityProcessor(
+            custom_preprocessor_path=CLIP_PROCESSOR_PATH,
+            signal_start_end_unit="frames",
+        )
+        proc_sliced = VideoModalityProcessor(
+            custom_preprocessor_path=CLIP_PROCESSOR_PATH,
+            signal_start_end_unit="frames",
+        )
+        tensor_full = proc_full.process_sample(dummy_video_file)
+        tensor_sliced = proc_sliced.process_sample(
+            {"signal": dummy_video_file, "signal_start": 2, "signal_end": 7}
+        )
+        # dummy_video_file has 10 frames; requesting frames 2..7 should yield fewer
+        assert tensor_sliced.shape[0] < tensor_full.shape[0]
+        assert tensor_sliced.shape[0] <= 5  # at most 5 frames in [2, 7)

--- a/tests/test_data/test_processor_video2text.py
+++ b/tests/test_data/test_processor_video2text.py
@@ -1,12 +1,14 @@
 """Tests for Video2TextTranslationProcessor."""
 
 import numpy as np
+import pytest
 import torch
 from transformers.feature_extraction_utils import BatchFeature
 
 from multimodalhugs.processors.legacy.video2text_preprocessor import (
     Video2TextTranslationProcessor,
 )
+from multimodalhugs.processors.video_modality_processor import VideoModalityProcessor
 
 
 def _modality_proc(processor):
@@ -130,3 +132,51 @@ class TestVideoProcessorCall:
                 assert val.shape[0] == batch_size, (
                     f"Key '{key}' has batch dim {val.shape[0]}, expected {batch_size}"
                 )
+
+
+class TestVideoSignalStartEndUnit:
+    """Tests for the signal_start_end_unit parameter on VideoModalityProcessor."""
+
+    def test_default_unit_is_milliseconds(self):
+        proc = VideoModalityProcessor()
+        assert proc.signal_start_end_unit == "milliseconds"
+
+    def test_frames_unit_accepted(self, dummy_video_file):
+        proc = VideoModalityProcessor(signal_start_end_unit="frames")
+        tensor = proc.process_sample(dummy_video_file)
+        assert isinstance(tensor, torch.Tensor)
+        assert tensor.ndim == 4  # (T, C, H, W)
+
+    def test_invalid_unit_raises(self):
+        with pytest.raises(ValueError, match="signal_start_end_unit"):
+            VideoModalityProcessor(signal_start_end_unit="seconds")
+
+    def test_frames_unit_slices_output(self, dummy_video_file):
+        """Requesting frames 0..5 should yield fewer frames than the full file."""
+        proc = VideoModalityProcessor(signal_start_end_unit="frames")
+        tensor_full = proc.process_sample(dummy_video_file)
+        tensor_sliced = proc.process_sample(
+            {"signal": dummy_video_file, "signal_start": 0, "signal_end": 5}
+        )
+        assert tensor_sliced.shape[0] == 5
+        assert tensor_full.shape[0] > tensor_sliced.shape[0]
+
+    def test_frames_unit_zero_zero_loads_full_file(self, dummy_video_file):
+        """signal_start=0, signal_end=0 with unit='frames' loads the full file."""
+        proc_ms = VideoModalityProcessor(signal_start_end_unit="milliseconds")
+        proc_fr = VideoModalityProcessor(signal_start_end_unit="frames")
+        t_ms = proc_ms.process_sample(
+            {"signal": dummy_video_file, "signal_start": 0, "signal_end": 0}
+        )
+        t_fr = proc_fr.process_sample(
+            {"signal": dummy_video_file, "signal_start": 0, "signal_end": 0}
+        )
+        assert t_ms.shape[0] == t_fr.shape[0]
+
+    def test_legacy_wrapper_passes_unit_through(self, tokenizer, dummy_video_file):
+        """Video2TextTranslationProcessor should propagate signal_start_end_unit."""
+        proc = Video2TextTranslationProcessor(
+            tokenizer=tokenizer,
+            signal_start_end_unit="frames",
+        )
+        assert _modality_proc(proc).signal_start_end_unit == "frames"

--- a/tests/test_data/test_processor_video2text.py
+++ b/tests/test_data/test_processor_video2text.py
@@ -172,6 +172,7 @@ class TestVideoSignalStartEndUnit:
         t_fr = proc_fr.process_sample(
             {"signal": dummy_video_file, "signal_start": 0, "signal_end": 0}
         )
+        assert t_ms.shape[0] > 0  # ensure at least some frames were loaded
         assert t_ms.shape[0] == t_fr.shape[0]
 
     def test_legacy_wrapper_passes_unit_through(self, tokenizer, dummy_video_file):


### PR DESCRIPTION
Closes #92

## Summary

Adds a `signal_start_end_unit` parameter (`SignalUnit.MILLISECONDS` | `SignalUnit.FRAMES`) to `PoseModalityProcessor`, `VideoModalityProcessor`, `Pose2TextDataConfig`, and `Video2TextDataConfig`. When set to `SignalUnit.FRAMES`, `signal_start` / `signal_end` values in the TSV metadata are interpreted as frame indices rather than milliseconds.

### Key implementation details

- **`PoseModalityProcessor`**: passes `start_frame` / `end_frame` directly to `Pose.read`, which uses a seek-capable `BytesIOReader` — no full-file load needed. Normalisation sees only the requested window, consistent with the milliseconds path.
- **`VideoModalityProcessor`** (OpenCV path): uses `CAP_PROP_POS_FRAMES` for seeking and boundary checks. Torchvision path: loads full video and slices by index (torchvision has no native frame-index seeking).
- **Dataset configs**: `Pose2TextDataConfig` / `Video2TextDataConfig` expose the parameter; duration filtering in `mapping_function` respects the chosen unit.
- **`SignalUnit` enum** (`StrEnum`, Python 3.8+ compatible): replaces bare strings for the unit parameter across all affected classes, providing type safety and IDE autocomplete.
- Legacy wrappers (`Pose2TextTranslationProcessor`, `Video2TextTranslationProcessor`) accept and forward the parameter.
- The zero/zero convention (`signal_start=0, signal_end=0` → full file) is preserved for both units.