### PR TITLE
Only accept one person per frame in pose processor

### DIFF
--- a/multimodalhugs/processors/pose_modality_processor.py
+++ b/multimodalhugs/processors/pose_modality_processor.py
@@ -113,6 +113,12 @@ class PoseModalityProcessor(ModalityProcessor):
             with open(pose_file, "rb") as f:
                 pose = Pose.read(f, start_frame=start_f, end_frame=end_f)
 
+        # Some estimators (e.g. OpenPose) can detect multiple people, but in
+        # sign language data there is almost always a single signer. Keeping
+        # only the first person is therefore a safe default heuristic and
+        # avoids downstream shape mismatches when extra detections are spurious.
+        pose.body.data = pose.body.data[:, :1]
+        pose.body.confidence = pose.body.confidence[:, :1]
         pose_hide_legs(pose)
         if self.reduce_holistic_poses:
             pose = reduce_holistic(pose)

--- a/multimodalhugs/processors/pose_modality_processor.py
+++ b/multimodalhugs/processors/pose_modality_processor.py
@@ -1,7 +1,10 @@
+import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 import torch
+
+logger = logging.getLogger(__name__)
 
 try:
     from pose_format import Pose
@@ -117,6 +120,14 @@ class PoseModalityProcessor(ModalityProcessor):
         # sign language data there is almost always a single signer. Keeping
         # only the first person is therefore a safe default heuristic and
         # avoids downstream shape mismatches when extra detections are spurious.
+        n_people = pose.body.data.shape[1]
+        if n_people > 1:
+            logger.warning(
+                "Pose file '%s' contains %d people; truncating to person 0. "
+                "This is the expected behaviour for single-signer data.",
+                pose_file,
+                n_people,
+            )
         pose.body.data = pose.body.data[:, :1]
         pose.body.confidence = pose.body.confidence[:, :1]
         pose_hide_legs(pose)


### PR DESCRIPTION
## Summary

- Restricts pose `body.data` and `body.confidence` to the first person (`[:, :1]`) after reading in `PoseModalityProcessor`
- Adds a comment explaining the rationale: some estimators (e.g. OpenPose) can detect multiple people, but in sign language data there is almost always a single signer, making this a safe default heuristic
- Applies the intent of commit 881f4b7 from @catherine-o-brien to the current master architecture

## Test plan

- [ ] Run pose-based tests: `pytest tests/ --ignore=tests/e2e_overfitting -v -k pose`
- [ ] Verify that single-person pose files process correctly end-to-end
- [ ] Verify that multi-person pose files are silently reduced to the first person without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)