### PR TITLE
fix: pass self when delegating prediction_step to base Trainer

### DIFF
--- a/multimodalhugs/multilingual_seq2seq_trainer.py
+++ b/multimodalhugs/multilingual_seq2seq_trainer.py
@@ -130,7 +130,7 @@ class MultiLingualSeq2SeqTrainer(Seq2SeqTrainer):
         gen_kwargs = self.model.generation_config.to_dict()
         if not self.args.predict_with_generate or prediction_loss_only:
             return Trainer.prediction_step(
-                model, inputs, prediction_loss_only=prediction_loss_only, ignore_keys=ignore_keys
+                self, model, inputs, prediction_loss_only=prediction_loss_only, ignore_keys=ignore_keys
             )
         has_labels = "labels" in inputs
         inputs = self._prepare_inputs(inputs)


### PR DESCRIPTION
Fixes #97.

`Trainer.prediction_step` is referenced as an unbound method via the class, so the call must pass `self` explicitly. Without it, `model` was bound to `self` and `inputs` was unfilled, raising:

```
TypeError: Trainer.prediction_step() missing 1 required positional argument: 'inputs'
```

This path is hit whenever `prediction_loss_only=True`, which the base `Trainer.evaluate()` sets when `compute_metrics is None` (i.e. `metric_name` not configured).